### PR TITLE
Harden admin, ingest, and serving-runtime stalls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ target/
 .dev/
 .pi/
 
+# local review dumps (findings, smoketests, notes — not for the repo)
+.review/
+
 # built web assets (embedded into the binary at build time; `just web-build`)
 web/dist/
 web/node_modules/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ machines whose "disk" is 20 GiB of tmpfs, next to a long tail of small repositor
   client: SSE envelope for the web UI, sideband band-2 lines for git. "Cloning into… and then nothing" is a bug.
 
 ### 1.3 Security contract (`Config::validate` fails closed)
-- Three auth modes (`server.auth.mode`): **`none`** (everyone is `anon` with write — loopback only),
+- Three auth modes (`server.auth.mode`): **`none`** (everyone is `anon` with write and admin — `validate` refuses unless `server.listen` is loopback),
   **`token`** (static tokens from the config, as `Authorization: Bearer` or an HTTP Basic password), **`oidc`**
   (any OpenID Connect issuer via discovery). In `oidc` mode `anonymous_read` must be false and an allowlist
   (`allowed_domains`/`allowed_emails`) must exist; three credentials are accepted — an ID token from the issuer
@@ -93,7 +93,7 @@ machines whose "disk" is 20 GiB of tmpfs, next to a long tail of small repositor
 - **An edge announces what it took over, per request, in `X-Walgit-Capabilities`** (D39): `client-authorization`
   (the client's bearer travels in `X-Walgit-Authorization`; `Authorization` is the hop's own credential and is
   never read as the client's) and `accel-redirect` (static bytes by `X-Accel-Redirect`, honoured only when
-  `server.accel_redirect = true`). Hit directly, nothing is assumed.
+  `server.accel_redirect = true` **and the TCP peer is loopback**). Hit directly, nothing is assumed.
 - **The installer** (`crates/walgit-server/src/setup.rs`, POSIX sh, idempotent): git ≥ 2.46 + curl; pins a
   self-signed host's CA; takes the token from `$WALGIT_TOKEN`, an already stored one, or the terminal (no terminal:
   exit 2 with the two things to do); writes `~/.config/git/<host>-token` (0600) and the credential helper
@@ -342,7 +342,10 @@ decision in §4 — or the PR is; never "fix later".
   as a `SETTINGS` log entry **and inline on `manifest.pb`** (every refs-level sync sees the effective config at no
   extra round trip). Effective config = host `walgit.toml` ⊕ env ⊕ settings (`Config::with_settings`). Validated at
   publish; invalid = 400, nothing published. Surface: `GET|PUT|DELETE /{o}/{r}/api/settings`, `…/effective`,
-  `…/history`; `walgit repo settings show|set|clear|history`. Not in settings: auth, store, server, wal, cache.
+  `…/history`; `walgit repo settings show|set|clear|history`. Not in settings: auth, store, server, wal, cache,
+  `upstream.token_env` (host-only). `GET …/effective` returns only those sections. PUT/DELETE of settings and of
+  `policy.json` require an **admin** principal (`tokens[].admin`, or oidc `admin_emails`/`admin_domains`;
+  `mode = none` is admin on loopback). Write is push, not admin.
 - **D25** **Two cache modes.** `cache.mode = "budget" | "disk" | "auto"` (auto = disk when `maintenance.disk =
   "ssd"`); in **disk** mode `cache_budget_bytes()` is 0 = unlimited — every repo fully local, never the
   too-large/remote/link path, eviction only under disk pressure (`cache.disk_high_watermark`, idle-oldest first).

--- a/crates/walgit-config/src/lib.rs
+++ b/crates/walgit-config/src/lib.rs
@@ -62,7 +62,9 @@ pub struct ServerConfig {
     /// `X-Accel-Redirect: /_store/` + `X-Walgit-Store-Url` (and `-Authorization`) and no
     /// body, so nginx streams (and caches) the bytes itself. Only turn it on behind an
     /// edge that strips the capability header from clients: the answer carries a store
-    /// credential. Off by default.
+    /// credential. Off by default. Even when on, accel is honoured only for loopback
+    /// peers (the example nginx talks to `127.0.0.1`) so a client on a public bind
+    /// cannot spoof the capability header and steal the store credential.
     pub accel_redirect: bool,
     /// Browser origins allowed to call `/api/*` cross-origin with credentials
     /// (the `repos.js` browser lane from other sites). Exact origins or one
@@ -159,6 +161,12 @@ pub struct AuthConfig {
     /// server — the host that fronts a push broker. Names as they authenticate here (a static
     /// token's `principal`, or an email).
     pub trusted_forwarders: Vec<String>,
+    /// OIDC emails that may PUT/DELETE settings and `policy.json`. Empty = none via email.
+    #[serde(default)]
+    pub admin_emails: Vec<String>,
+    /// OIDC email domains that may PUT/DELETE settings and `policy.json`. Empty = none via domain.
+    #[serde(default)]
+    pub admin_domains: Vec<String>,
     /// HMAC key for the browser session cookie and for walgit-issued access tokens
     /// (`oidc` mode). Unset = cookie sessions and issued tokens off. When set, must be ≥ 32
     /// bytes; shared by every host that answers a browser.
@@ -185,7 +193,8 @@ pub const ACCESS_TOKEN_PREFIX: &str = "wgt_";
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum AuthMode {
-    /// Everyone is `anon` with write. Loopback experiments only.
+    /// Everyone is `anon` with write **and admin**. `Config::validate` refuses this
+    /// unless `server.listen` is loopback.
     #[default]
     None,
     /// Static tokens from the config (`tokens`), bearer or basic.
@@ -205,6 +214,9 @@ pub struct StaticToken {
     pub token_env: Option<String>,
     #[serde(default = "default_true")]
     pub write: bool,
+    /// Mutate per-repo settings and `policy.json`. Default false: write is push, not admin.
+    #[serde(default)]
+    pub admin: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -817,6 +829,12 @@ impl Config {
                 SETTINGS_SECTIONS.join(", ")
             );
         }
+        if let Some(toml::Value::Table(u)) = overrides.get("upstream") {
+            anyhow::ensure!(
+                !u.contains_key("token_env"),
+                "settings: upstream.token_env is host-only (it names an env var on the maintaining host)"
+            );
+        }
         let mut doc: toml::Table = toml::Table::try_from(self).context("serializing config")?;
         fn merge(into: &mut toml::Table, from: &toml::Table) {
             for (k, v) in from {
@@ -833,6 +851,17 @@ impl Config {
         cfg.validate()
             .context("settings: validating the effective config")?;
         Ok(cfg)
+    }
+
+    /// The effective config a reader may see: only [`SETTINGS_SECTIONS`], and
+    /// never `upstream.token_env` (that name is host-only).
+    pub fn public_settings_toml(&self) -> Result<String> {
+        let mut doc: toml::Table = toml::Table::try_from(self).context("serializing config")?;
+        doc.retain(|k, _| SETTINGS_SECTIONS.iter().any(|s| *s == k));
+        if let Some(toml::Value::Table(u)) = doc.get_mut("upstream") {
+            u.remove("token_env");
+        }
+        toml::to_string_pretty(&doc).context("encoding settings")
     }
 
     /// D25: the effective on-disk budget — `cache.max_bytes` in budget mode,
@@ -1002,7 +1031,7 @@ impl Default for Config {
 impl Default for ServerConfig {
     fn default() -> Self {
         ServerConfig {
-            listen: "0.0.0.0:8080".parse().unwrap(),
+            listen: "127.0.0.1:8080".parse().unwrap(),
             http2: true,
             max_concurrent_requests: 512,
             max_concurrent_per_repo: 64,
@@ -1031,6 +1060,8 @@ impl Default for AuthConfig {
             audiences: vec![],
             write_domains: None,
             trusted_forwarders: vec![],
+            admin_emails: vec![],
+            admin_domains: vec![],
             session_secret: None,
             session_ttl: Duration::from_secs(30 * 24 * 3600),
             access_token_ttl: Duration::from_secs(90 * 24 * 3600),
@@ -1437,6 +1468,13 @@ impl Config {
         }
         // Security contract: identity modes fail closed.
         let a = &self.server.auth;
+        if a.mode == AuthMode::None {
+            anyhow::ensure!(
+                self.server.listen.ip().is_loopback(),
+                "server.auth.mode = none is loopback-only (listen is {}); use token or oidc for a public bind",
+                self.server.listen
+            );
+        }
         if a.mode == AuthMode::Token {
             anyhow::ensure!(
                 !a.tokens.is_empty(),
@@ -1868,6 +1906,16 @@ listen = \"0.0.0.0:1\"\n",
             base.with_settings("  ").unwrap().bundles.min_commits,
             base.bundles.min_commits
         );
+        let e = base
+            .with_settings("[upstream]\ntoken_env = \"AWS_SECRET_ACCESS_KEY\"\n")
+            .unwrap_err()
+            .to_string();
+        assert!(e.contains("token_env"), "{e}");
+        let pub_toml = base.public_settings_toml().unwrap();
+        assert!(pub_toml.contains("[bundles]"), "{pub_toml}");
+        assert!(!pub_toml.contains("session_secret"), "{pub_toml}");
+        assert!(!pub_toml.contains("[server]"), "{pub_toml}");
+        assert!(!pub_toml.contains("token_env"), "{pub_toml}");
     }
 
     #[test]
@@ -1901,6 +1949,11 @@ audiences = ["walgit-cli", "https://git.example.com"]
             ok.server.auth.access_token_ttl,
             Duration::from_secs(90 * 86400)
         );
+        let err = Config::parse(
+            "[store]\nbucket = \"b\"\n[server]\nlisten = \"0.0.0.0:8080\"\n[server.auth]\nmode = \"none\"\n",
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("loopback-only"), "{err}");
     }
 
     #[test]

--- a/crates/walgit-git/src/lib.rs
+++ b/crates/walgit-git/src/lib.rs
@@ -62,7 +62,80 @@ fn ge<E: std::error::Error + Send + Sync + 'static>(e: E) -> GitError {
     GitError::Gix(Box::new(e))
 }
 
+/// Reject ref names that would inject `git update-ref --stdin` commands or
+/// poison packed-refs (newlines, NULs, git-illegal bytes).
+pub fn validate_ref_name(name: &str) -> Result<(), GitError> {
+    if name == "HEAD" {
+        return Ok(());
+    }
+    let bad = name.is_empty()
+        || !name.starts_with("refs/")
+        || name.bytes().any(|b| {
+            matches!(
+                b,
+                0 | b'\n' | b'\r' | b' ' | b'~' | b'^' | b':' | b'?' | b'*' | b'[' | b'\\'
+            )
+        })
+        || name.contains("..")
+        || name.contains("@{")
+        || name.contains("//")
+        || name.starts_with('/')
+        || name.ends_with('/')
+        || name.ends_with('.')
+        || name.ends_with(".lock");
+    if bad {
+        Err(GitError::InvalidInput(format!("invalid ref name {name:?}")))
+    } else {
+        Ok(())
+    }
+}
+
+/// Full hex oid (sha1 40 or sha256 64). Empty / all-zeros is a delete/create marker.
+pub fn validate_oid(oid: &str) -> Result<(), GitError> {
+    if oid.is_empty() || oid.bytes().all(|b| b == b'0') {
+        return Ok(());
+    }
+    let n = oid.len();
+    if (n == 40 || n == 64) && oid.bytes().all(|b| b.is_ascii_hexdigit()) {
+        Ok(())
+    } else {
+        Err(GitError::InvalidInput(format!("invalid oid {oid:?}")))
+    }
+}
+
+pub fn validate_ref_update(u: &walgit_proto::v1::RefUpdate) -> Result<(), GitError> {
+    if !u.new_symbolic_target.is_empty() {
+        if u.name != "HEAD" {
+            return Err(GitError::InvalidInput(format!(
+                "symbolic update is only allowed for HEAD, got {:?}",
+                u.name
+            )));
+        }
+        return validate_ref_name(&u.new_symbolic_target);
+    }
+    validate_ref_name(&u.name)?;
+    validate_oid(&u.old_oid)?;
+    validate_oid(&u.new_oid)
+}
+
 const WALGIT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[cfg(test)]
+mod validate_ref_tests {
+    use super::*;
+
+    #[test]
+    fn ref_names_reject_injection() {
+        assert!(validate_ref_name("HEAD").is_ok());
+        assert!(validate_ref_name("refs/heads/main").is_ok());
+        assert!(validate_ref_name("refs/heads/foo\nupdate refs/heads/main").is_err());
+        assert!(validate_ref_name("refs/heads/foo\0bar").is_err());
+        assert!(validate_ref_name("../etc/passwd").is_err());
+        assert!(validate_oid(&"0".repeat(40)).is_ok());
+        assert!(validate_oid("gg").is_err());
+        assert!(validate_oid(&"a".repeat(40)).is_ok());
+    }
+}
 
 // ---------------------------------------------------------------------------
 // RepoId
@@ -613,6 +686,15 @@ impl LocalRepo {
         gix::Repository::from(&*tsr)
     }
 
+    /// Re-open so gix sees new packed-refs / HEAD without remapping pack indexes.
+    /// Ref-only writers use this; pack installs use [`refresh`].
+    pub fn refresh_refs(&self) -> Result<(), GitError> {
+        self.refs_changed();
+        let tsr = gix::ThreadSafeRepository::open(&self.inner.path).map_err(ge)?;
+        *self.inner.tsr.lock() = tsr;
+        Ok(())
+    }
+
     /// Re-open the underlying repository so the odb/refs reflect on-disk
     /// changes from pack/ref writes.
     pub fn refresh(&self) -> Result<(), GitError> {
@@ -1071,6 +1153,10 @@ impl LocalRepo {
                 .cloned()
         };
 
+        for u in &txn.updates {
+            validate_ref_update(u)?;
+        }
+
         // Pre-check old values for clear error reporting.
         if check_old {
             let view = self.ref_view()?;
@@ -1179,15 +1265,15 @@ impl LocalRepo {
 
         // Apply symbolic ref updates by writing the HEAD file directly.
         for u in &symref_updates {
-            let head_path = self.inner.path.join(&u.name);
+            let head_path = self.inner.path.join("HEAD");
             std::fs::write(&head_path, format!("ref: {}\n", u.new_symbolic_target))
                 .map_err(GitError::Io)?;
         }
         // Patch the snapshot we started from instead of throwing it away: re-parsing
         // packed-refs + peeling 100 k tags was the O(refs) term every push handed to the next
-        // request (~700 ms debug / ~200 ms release at 500 k refs, AGENTS §1.4). `refresh()`
-        // bumps the generation; the patched data is installed under the new key.
-        self.refresh()?;
+        // request (~700 ms debug / ~200 ms release at 500 k refs, AGENTS §1.4). `refresh_refs()`
+        // bumps the generation without remapping pack indexes.
+        self.refresh_refs()?;
         self.refs_changed();
         if let Some(mut c) = before {
             c.pending.push(txn.clone());
@@ -1292,7 +1378,7 @@ impl LocalRepo {
             std::fs::write(path.join("HEAD"), format!("ref: {}\n", snap.head_target))
                 .map_err(GitError::Io)?;
         }
-        self.refresh()?;
+        self.refresh_refs()?;
         Ok(())
     }
 
@@ -1323,6 +1409,7 @@ impl LocalRepo {
         let repo = self.gix();
         for txn in txns {
             for u in &txn.updates {
+                validate_ref_update(u)?;
                 if !u.new_symbolic_target.is_empty() {
                     if u.name == "HEAD" {
                         head_target = u.new_symbolic_target.clone();
@@ -1364,7 +1451,7 @@ impl LocalRepo {
 
     pub fn pack_refs(&self) -> Result<(), GitError> {
         self.git_cmd_sync(&["pack-refs", "--all", "--prune"])?;
-        self.refresh()?;
+        self.refresh_refs()?;
         Ok(())
     }
 

--- a/crates/walgit-git/src/receive.rs
+++ b/crates/walgit-git/src/receive.rs
@@ -198,6 +198,7 @@ fn parse_command_line(b: &[u8]) -> Result<(walgit_proto::v1::RefUpdate, String),
         new_symbolic_target: String::new(),
         new_peeled: String::new(),
     };
+    crate::validate_ref_update(&update)?;
     Ok((update, String::from_utf8_lossy(caps_bytes).to_string()))
 }
 

--- a/crates/walgit-git/src/upload_gix.rs
+++ b/crates/walgit-git/src/upload_gix.rs
@@ -274,7 +274,7 @@ impl LocalRepo {
                         oid: missing[0].to_hex().to_string(),
                     });
                 }
-                self.refresh()?;
+                self.refresh_async().await?;
             }
         }
 
@@ -323,7 +323,7 @@ impl LocalRepo {
                             oid: missing[0].to_hex().to_string(),
                         });
                     }
-                    self.refresh()?;
+                    self.refresh_async().await?;
                 }
             }
         };
@@ -368,7 +368,7 @@ impl LocalRepo {
                         oid: missing[0].to_hex().to_string(),
                     });
                 }
-                self.refresh()?;
+                self.refresh_async().await?;
             }
         }
 

--- a/crates/walgit-git/tests/receive.rs
+++ b/crates/walgit-git/tests/receive.rs
@@ -60,6 +60,18 @@ async fn parse_receive_pack_commands_and_push_options() {
 }
 
 #[tokio::test]
+async fn parse_receive_rejects_newline_in_ref_name() {
+    let zero = "0".repeat(40);
+    let new = "a".repeat(40);
+    let mut body = Vec::new();
+    let line = format!("{zero} {new} refs/heads/foo\nupdate refs/heads/main {new}");
+    encode_data(&mut body, line.as_bytes());
+    encode_flush(&mut body);
+    let err = receive::parse(&body[..]).await.unwrap_err().to_string();
+    assert!(err.contains("invalid ref name"), "{err}");
+}
+
+#[tokio::test]
 async fn parse_receive_no_commands() {
     let mut body = Vec::new();
     encode_flush(&mut body);

--- a/crates/walgit-proto/src/lib.rs
+++ b/crates/walgit-proto/src/lib.rs
@@ -77,8 +77,17 @@ pub mod keys {
     pub fn lease_key(name: &str) -> String {
         format!("{LEASES_DIR}{name}.pb")
     }
+    /// Git LFS oid: 64 hex characters (sha256).
+    pub fn lfs_oid_ok(oid: &str) -> bool {
+        oid.len() == 64 && oid.bytes().all(|b| b.is_ascii_hexdigit())
+    }
+
     pub fn lfs_key(oid: &str) -> String {
-        format!("{LFS_DIR}{}/{}/{oid}", &oid[0..2], &oid[2..4])
+        let (aa, bb) = match (oid.get(..2), oid.get(2..4)) {
+            (Some(a), Some(b)) => (a, b),
+            _ => ("", ""),
+        };
+        format!("{LFS_DIR}{aa}/{bb}/{oid}")
     }
 }
 
@@ -171,6 +180,10 @@ mod tests {
             "checkpoints/0000000000000001/checkpoint.pb"
         );
         assert_eq!(keys::lfs_key("abcdef"), "lfs/objects/ab/cd/abcdef");
+        assert!(!keys::lfs_oid_ok("ab"));
+        assert!(!keys::lfs_oid_ok("abcdef"));
+        assert!(keys::lfs_oid_ok(&"a".repeat(64)));
+        assert_eq!(keys::lfs_key("ab"), "lfs/objects///ab");
     }
     #[test]
     fn frames_roundtrip_and_partial() {

--- a/crates/walgit-server/src/auth.rs
+++ b/crates/walgit-server/src/auth.rs
@@ -55,6 +55,8 @@ fn unix_now() -> Option<u64> {
 pub struct Principal {
     pub name: String,
     pub write: bool,
+    /// PUT/DELETE settings and `policy.json`. Independent of `write` (push).
+    pub admin: bool,
     pub anonymous: bool,
 }
 
@@ -63,6 +65,7 @@ impl Principal {
         Self {
             name: "anonymous".to_string(),
             write: false,
+            admin: false,
             anonymous: true,
         }
     }
@@ -361,6 +364,8 @@ pub struct Authenticator {
     allowed_domains: Vec<String>,
     allowed_emails: Vec<String>,
     trusted_forwarders: Vec<String>,
+    admin_emails: Vec<String>,
+    admin_domains: Vec<String>,
     /// Accepted `aud` of bearer ID tokens (`audiences` ∪ `oauth_client_id`).
     audiences: Vec<String>,
     write_domains: Option<Vec<String>>,
@@ -421,6 +426,16 @@ impl Authenticator {
                 .collect(),
             trusted_forwarders: auth
                 .trusted_forwarders
+                .iter()
+                .map(|v| v.to_ascii_lowercase())
+                .collect(),
+            admin_emails: auth
+                .admin_emails
+                .iter()
+                .map(|v| v.to_ascii_lowercase())
+                .collect(),
+            admin_domains: auth
+                .admin_domains
                 .iter()
                 .map(|v| v.to_ascii_lowercase())
                 .collect(),
@@ -625,6 +640,7 @@ impl Authenticator {
             return Ok(Principal {
                 name: forwarded.to_string(),
                 write: caller.write,
+                admin: self.is_admin(forwarded),
                 anonymous: false,
             });
         }
@@ -637,6 +653,7 @@ impl Authenticator {
             return Some(Ok(Principal {
                 name: st.principal.clone(),
                 write: st.write,
+                admin: st.admin,
                 anonymous: false,
             }));
         }
@@ -654,6 +671,7 @@ impl Authenticator {
             AuthMode::None => Ok(Principal {
                 name: "anon".to_string(),
                 write: true,
+                admin: true,
                 anonymous: false,
             }),
             AuthMode::Token => {
@@ -685,7 +703,7 @@ impl Authenticator {
         }
     }
 
-    /// Require a principal with `write` for write/admin operations.
+    /// Require a principal with `write` for git push / LFS upload / repo create.
     pub async fn require_write(&self, headers: &HeaderMap) -> Result<Principal, AuthError> {
         let p = self.authenticate(headers).await?;
         if p.write {
@@ -693,6 +711,34 @@ impl Authenticator {
         } else {
             Err(AuthError::Forbidden)
         }
+    }
+
+    /// Require a principal that may mutate settings and `policy.json`.
+    pub async fn require_admin(&self, headers: &HeaderMap) -> Result<Principal, AuthError> {
+        let p = self.authenticate(headers).await?;
+        if p.admin {
+            Ok(p)
+        } else {
+            Err(AuthError::Forbidden)
+        }
+    }
+
+    fn is_admin(&self, name: &str) -> bool {
+        if self.mode == AuthMode::None {
+            return true;
+        }
+        let lower = name.to_ascii_lowercase();
+        if self.admin_emails.iter().any(|e| e == &lower) {
+            return true;
+        }
+        if let Some((_, domain)) = lower.rsplit_once('@')
+            && self.admin_domains.iter().any(|d| d == domain)
+        {
+            return true;
+        }
+        self.tokens
+            .iter()
+            .any(|t| t.admin && t.principal.eq_ignore_ascii_case(name))
     }
 
     /// Require read access: anonymous read only when `anonymous_read` allows it.
@@ -770,8 +816,9 @@ impl Authenticator {
             Some(domains) => domains.iter().any(|d| d == &domain_lower),
         };
         Ok(Principal {
-            name: email,
+            name: email.clone(),
             write,
+            admin: self.is_admin(&email),
             anonymous: false,
         })
     }
@@ -933,6 +980,7 @@ fn resolve_tokens(tokens: &[StaticToken]) -> Vec<StaticToken> {
                 token,
                 token_env: None,
                 write: t.write,
+                admin: t.admin,
             }
         })
         .filter(|t| !t.token.is_empty())
@@ -1093,6 +1141,7 @@ GcZ0izY/30012ajdHY+/QK5lsMoxTnn0skdS+spLxaS5ZEO4qvPVb8RAoCkWMMal
             token: token.into(),
             token_env: None,
             write,
+            admin: false,
         }
     }
 

--- a/crates/walgit-server/src/bundles.rs
+++ b/crates/walgit-server/src/bundles.rs
@@ -113,6 +113,7 @@ pub async fn object(
     route: &RepoRoute,
     method: &Method,
     headers: &HeaderMap,
+    peer: Option<std::net::SocketAddr>,
 ) -> Result<Response, ApiError> {
     let _ = st.auth.require_read(headers).await.map_err(auth_err)?;
     let handle = open_repo(st, &route.id, false).await?;
@@ -137,6 +138,7 @@ pub async fn object(
         static_object::ServeOptions {
             content_type: "application/x-git-bundle",
             accel: st.cfg.server.accel_redirect,
+            peer,
             ..Default::default()
         },
     )

--- a/crates/walgit-server/src/lfs.rs
+++ b/crates/walgit-server/src/lfs.rs
@@ -90,6 +90,9 @@ pub async fn batch(
     let cfg = handle.effective_config();
 
     let is_upload = body.operation == "upload";
+    for o in &body.objects {
+        require_lfs_oid(&o.oid)?;
+    }
     // Local presence first; then one bounded upstream batch for the misses.
     let mut local = Vec::with_capacity(body.objects.len());
     let mut missing = Vec::new();
@@ -214,6 +217,7 @@ pub async fn get_object(
     method: &axum::http::Method,
     headers: &HeaderMap,
     query: &str,
+    peer: Option<std::net::SocketAddr>,
 ) -> Result<Response, ApiError> {
     if !st.cfg.lfs.enabled {
         return Err(ApiError::NotFound("lfs disabled".into()));
@@ -221,6 +225,7 @@ pub async fn get_object(
     let _ = st.auth.require_read(headers).await.map_err(auth_err)?;
     not_served_here(st, &route.id)?;
     let oid = route_sub_last(&route.subpath)?;
+    require_lfs_oid(oid)?;
     let handle = open_repo(st, &route.id, false).await?;
     let store = handle.store().clone();
     let key = keys::lfs_key(oid);
@@ -242,6 +247,7 @@ pub async fn get_object(
         headers,
         crate::static_object::ServeOptions {
             accel: st.cfg.server.accel_redirect,
+            peer,
             ..Default::default()
         },
     )
@@ -387,26 +393,53 @@ pub async fn put_object(
     let _ = st.auth.require_write(headers).await.map_err(auth_err)?;
     not_served_here(st, &route.id)?;
     let oid = route_sub_last(&route.subpath)?;
+    require_lfs_oid(oid)?;
     let handle = open_repo(st, &route.id, false).await?;
     let store = handle.store().clone();
     let key = keys::lfs_key(oid);
+    let max = st.cfg.lfs.max_object_bytes.as_u64();
 
+    let tmp = tempfile::NamedTempFile::new().map_err(|e| ApiError::Internal(e.to_string()))?;
+    let mut file = tokio::fs::File::from_std(
+        tmp.reopen()
+            .map_err(|e| ApiError::Internal(e.to_string()))?,
+    );
     let mut reader = body_to_async_read(body);
-    use tokio::io::AsyncReadExt;
-    let mut buf = Vec::new();
-    reader
-        .read_to_end(&mut buf)
+    use sha2::{Digest, Sha256};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    let mut hasher = Sha256::new();
+    let mut n = 0u64;
+    let mut buf = vec![0u8; 64 * 1024];
+    loop {
+        let k = reader
+            .read(&mut buf)
+            .await
+            .map_err(|e| ApiError::Internal(e.to_string()))?;
+        if k == 0 {
+            break;
+        }
+        n += k as u64;
+        if n > max {
+            return Err(ApiError::PayloadTooLarge);
+        }
+        hasher.update(&buf[..k]);
+        file.write_all(&buf[..k])
+            .await
+            .map_err(|e| ApiError::Internal(e.to_string()))?;
+    }
+    file.flush()
         .await
         .map_err(|e| ApiError::Internal(e.to_string()))?;
-    if (buf.len() as u64) > st.cfg.lfs.max_object_bytes.as_u64() {
-        return Err(ApiError::PayloadTooLarge);
-    }
-    let hash = sha256_hex(&buf);
-    if hash != oid {
+    drop(file);
+    if hex::encode(hasher.finalize()) != oid {
         return Err(ApiError::BadRequest("lfs object sha256 mismatch".into()));
     }
     store
-        .put(&key, PutBody::from(buf), PutMode::Overwrite.into())
+        .put(
+            &key,
+            PutBody::File(tmp.path().to_path_buf()),
+            PutMode::Overwrite.into(),
+        )
         .await
         .map_err(store_err)?;
     Ok(StatusCode::OK.into_response())
@@ -424,6 +457,7 @@ pub async fn verify(
     }
     let body: BatchObject = serde_json::from_slice(&body_bytes)
         .map_err(|e| ApiError::BadRequest(format!("invalid lfs verify: {e}")))?;
+    require_lfs_oid(&body.oid)?;
     let _ = st.auth.require_write(headers).await.map_err(auth_err)?;
     let handle = open_repo(st, &route.id, false).await?;
     let store = handle.store().clone();
@@ -450,11 +484,12 @@ fn not_served_here(st: &AppState, id: &walgit_git::RepoId) -> Result<(), ApiErro
     }
 }
 
-fn sha256_hex(data: &[u8]) -> String {
-    use sha2::{Digest, Sha256};
-    let mut h = Sha256::new();
-    h.update(data);
-    hex::encode(h.finalize())
+fn require_lfs_oid(oid: &str) -> Result<(), ApiError> {
+    if keys::lfs_oid_ok(oid) {
+        Ok(())
+    } else {
+        Err(ApiError::BadRequest("invalid lfs oid".into()))
+    }
 }
 
 fn route_sub_last(subpath: &str) -> Result<&str, ApiError> {

--- a/crates/walgit-server/src/lib.rs
+++ b/crates/walgit-server/src/lib.rs
@@ -34,10 +34,12 @@ pub mod tls;
 pub mod web;
 
 use std::future::Future;
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use axum::Router;
 use axum::body::{Body, to_bytes};
+use axum::extract::ConnectInfo;
 use axum::http::{Method, Request};
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
@@ -305,12 +307,19 @@ async fn dispatch(
     let query = req.uri().query().unwrap_or("").to_string();
     let method = req.method().clone();
     let headers = req.headers().clone();
+    let peer = request_peer(&req);
     let body = req.into_body();
 
     let Some(route) = parse_repo_route(&path) else {
         return ApiError::NotFound("no such route".into()).into_response();
     };
-    dispatch_route(&st, &route, method, headers, query, body).await
+    dispatch_route(&st, &route, method, headers, query, body, peer).await
+}
+
+pub(crate) fn request_peer(req: &Request<Body>) -> Option<SocketAddr> {
+    req.extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|c| c.0)
 }
 
 /// Route a parsed repo request (`/{owner}/{repo}[.git]/<sub>` or the same sub
@@ -323,6 +332,7 @@ pub(crate) async fn dispatch_route(
     headers: axum::http::HeaderMap,
     query: String,
     body: Body,
+    peer: Option<SocketAddr>,
 ) -> Response {
     let mut body = Some(body);
     let sub = route.subpath.as_str();
@@ -347,7 +357,7 @@ pub(crate) async fn dispatch_route(
             (&Method::GET | &Method::HEAD, s)
                 if s.starts_with("info/lfs/objects/") && !s.ends_with("/batch") =>
             {
-                lfs::get_object(st, route, &method, &headers, &query).await
+                lfs::get_object(st, route, &method, &headers, &query, peer).await
             }
             (&Method::PUT, s) if s.starts_with("info/lfs/objects/") => {
                 lfs::put_object(st, route, &headers, body.take().unwrap()).await
@@ -365,7 +375,7 @@ pub(crate) async fn dispatch_route(
             (&Method::GET | &Method::HEAD, s)
                 if s.starts_with("bundles/") && s != "bundles/list" && s != "bundles/catchup" =>
             {
-                bundles::object(st, route, &method, &headers).await
+                bundles::object(st, route, &method, &headers, peer).await
             }
             (&Method::PUT, "") => admin::create(st, route, &headers, &query).await,
             (&Method::DELETE, "") => admin::delete(st, route, &headers).await,
@@ -570,9 +580,12 @@ pub async fn serve(
                 .await
             }
             None => {
-                axum::serve(NodelayListener(listener), app)
-                    .with_graceful_shutdown(graceful)
-                    .await
+                axum::serve(
+                    NodelayListener(listener),
+                    app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+                )
+                .with_graceful_shutdown(graceful)
+                .await
             }
         }
     };

--- a/crates/walgit-server/src/policy.rs
+++ b/crates/walgit-server/src/policy.rs
@@ -679,7 +679,7 @@ pub async fn http_put(
     headers: &HeaderMap,
     body: axum::body::Body,
 ) -> Result<Response, ApiError> {
-    let _ = st.auth.require_write(headers).await.map_err(auth_err)?;
+    let _ = st.auth.require_admin(headers).await.map_err(auth_err)?;
     ensure_repo(st, route).await?;
     let bytes = crate::collect_body(body).await?;
     let policy = parse_bytes(&bytes).map_err(store_err)?;
@@ -694,7 +694,7 @@ pub async fn http_delete(
     route: &RepoRoute,
     headers: &HeaderMap,
 ) -> Result<Response, ApiError> {
-    let _ = st.auth.require_write(headers).await.map_err(auth_err)?;
+    let _ = st.auth.require_admin(headers).await.map_err(auth_err)?;
     ensure_repo(st, route).await?;
     clear(&st.store, &route.id).await.map_err(store_err)?;
     Ok((StatusCode::NO_CONTENT, "").into_response())

--- a/crates/walgit-server/src/settings.rs
+++ b/crates/walgit-server/src/settings.rs
@@ -77,7 +77,9 @@ pub async fn http_effective(
     h.sync_refs()
         .await
         .map_err(|e| ApiError::Internal(e.to_string()))?;
-    let text = toml::to_string_pretty(&*h.effective_config())
+    let text = h
+        .effective_config()
+        .public_settings_toml()
         .map_err(|e| ApiError::Internal(e.to_string()))?;
     Ok((
         StatusCode::OK,
@@ -131,7 +133,7 @@ pub async fn http_put(
     query: &str,
     body: axum::body::Body,
 ) -> Result<Response, ApiError> {
-    let principal = st.auth.require_write(headers).await.map_err(auth_err)?;
+    let principal = st.auth.require_admin(headers).await.map_err(auth_err)?;
     let h = open(st, route).await?;
     let bytes = crate::collect_body(body).await?;
     if bytes.len() > walgit_config::SETTINGS_MAX_BYTES {
@@ -153,7 +155,7 @@ pub async fn http_delete(
     route: &RepoRoute,
     headers: &HeaderMap,
 ) -> Result<Response, ApiError> {
-    let principal = st.auth.require_write(headers).await.map_err(auth_err)?;
+    let principal = st.auth.require_admin(headers).await.map_err(auth_err)?;
     let h = open(st, route).await?;
     publish(&h, "", &principal.name, "clear").await
 }
@@ -294,6 +296,9 @@ fn describe_json(
         let host_map: std::collections::HashMap<String, toml::Value> =
             host_flat.into_iter().collect();
         for (k, v) in eff_flat {
+            if k.ends_with("token_env") {
+                continue;
+            }
             // Array-of-tables (strategies) count as set when the document has the array.
             let top = k.split('.').take(2).collect::<Vec<_>>().join(".");
             let is_set = set_keys.contains(&k)

--- a/crates/walgit-server/src/static_object.rs
+++ b/crates/walgit-server/src/static_object.rs
@@ -160,6 +160,10 @@ pub struct ServeOptions<'a> {
     /// has an object URL, answer `200` + `X-Accel-Redirect` (no body) and let the
     /// edge move the bytes. `false`: always stream from here.
     pub accel: bool,
+    /// TCP peer. Accel is honoured only when this is loopback (nginx on the
+    /// same host). A client on a public bind cannot spoof the capability
+    /// header and steal `X-Walgit-Store-Authorization`.
+    pub peer: Option<std::net::SocketAddr>,
 }
 
 impl Default for ServeOptions<'_> {
@@ -169,6 +173,7 @@ impl Default for ServeOptions<'_> {
             cache_control: None,
             filename: None,
             accel: false,
+            peer: None,
         }
     }
 }
@@ -238,7 +243,11 @@ pub async fn serve(
     // nginx fetches the object with its own credentials, slices Range itself and
     // caches the bytes on its disk, so a 32 GB bundle never ties up a worker on
     // this instance. HEAD stays local (metadata only, nothing to offload).
-    if opts.accel && !head && accel_requested(headers) {
+    if opts.accel
+        && !head
+        && accel_requested(headers)
+        && opts.peer.is_some_and(|p| p.ip().is_loopback())
+    {
         if let Some(target) = store.accel_target(key).await {
             let meta = match store.head(key).await {
                 Ok(Some(m)) => m,

--- a/crates/walgit-server/src/web/v1.rs
+++ b/crates/walgit-server/src/web/v1.rs
@@ -408,7 +408,8 @@ async fn repo_admin(
     let query = req.uri().query().unwrap_or("").to_string();
     let method = req.method().clone();
     let headers = req.headers().clone();
-    crate::dispatch_route(&st, &route, method, headers, query, req.into_body()).await
+    let peer = crate::request_peer(&req);
+    crate::dispatch_route(&st, &route, method, headers, query, req.into_body(), peer).await
 }
 
 #[cfg(test)]

--- a/crates/walgit-server/tests/e2e.rs
+++ b/crates/walgit-server/tests/e2e.rs
@@ -1539,12 +1539,14 @@ async fn bundles_require_allows_one_upload_pack_fallback_after_a_failed_bundle_a
                 token: "dev".into(),
                 token_env: None,
                 write: true,
+                admin: false,
             },
             walgit_config::StaticToken {
                 principal: "other@example.com".into(),
                 token: "other".into(),
                 token_env: None,
                 write: true,
+                admin: false,
             },
         ];
     })
@@ -2136,6 +2138,8 @@ async fn repo_settings_api_roundtrip() -> TestResult {
     assert!(r["toml"].as_str().unwrap().contains("min_commits = 2"));
     let eff = c.get(url(&a, "/effective")).send().await?.text().await?;
     assert!(eff.contains("min_commits = 2"), "{eff}");
+    assert!(!eff.contains("session_secret"), "{eff}");
+    assert!(!eff.contains("[server]"), "{eff}");
 
     // The sibling sees it (refs-level sync, no objects).
     let r: serde_json::Value = c.get(url(&b, "")).send().await?.json().await?;
@@ -2676,6 +2680,7 @@ async fn public_lane_serves_only_the_installer_without_auth() -> TestResult {
             token: "dev".into(),
             token_env: None,
             write: true,
+            admin: false,
         }];
     })
     .await?;
@@ -2735,6 +2740,7 @@ async fn stale_cached_credential_is_erased_by_the_401_and_replaced_on_the_next_c
             token: "fresh".into(),
             token_env: None,
             write: true,
+            admin: false,
         }];
     })
     .await?;

--- a/crates/walgit-server/tests/harness.rs
+++ b/crates/walgit-server/tests/harness.rs
@@ -122,12 +122,15 @@ impl Server {
         let app = router(state.clone());
         let (tx, rx) = tokio::sync::oneshot::channel::<()>();
         tokio::spawn(async move {
-            axum::serve(listener, app)
-                .with_graceful_shutdown(async move {
-                    let _ = rx.await;
-                })
-                .await
-                .ok();
+            axum::serve(
+                listener,
+                app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+            )
+            .with_graceful_shutdown(async move {
+                let _ = rx.await;
+            })
+            .await
+            .ok();
         });
 
         Ok(Self {

--- a/crates/walgit-wal/src/handle.rs
+++ b/crates/walgit-wal/src/handle.rs
@@ -279,15 +279,25 @@ impl RepoHandle {
         match self.begin_task("remote-index", HashMap::new()) {
             Begin::Started(task) => {
                 let reporter = task.reporter();
-                let res = RemotePacks::open(
-                    self.store.clone(),
-                    manifest,
-                    self.local.path(),
-                    self.local.object_format().kind(),
-                    self.blocks.clone(),
-                    self.cfg.cache.remote_object_bytes.as_u64(),
-                    &reporter,
-                )
+                let store = self.store.clone();
+                let manifest = manifest.clone();
+                let path = self.local.path().to_path_buf();
+                let hash = self.local.object_format().kind();
+                let blocks = self.blocks.clone();
+                let object_cache_bytes = self.cfg.cache.remote_object_bytes.as_u64();
+                let reporter_bulk = reporter.clone();
+                let res = crate::sync::on_bulk_runtime(async move {
+                    RemotePacks::open(
+                        store,
+                        &manifest,
+                        &path,
+                        hash,
+                        blocks,
+                        object_cache_bytes,
+                        &reporter_bulk,
+                    )
+                    .await
+                })
                 .instrument(task.span())
                 .await;
                 match res {

--- a/walgit.example.toml
+++ b/walgit.example.toml
@@ -6,7 +6,7 @@
 # Validate with: walgit config check walgit.toml
 
 [server]
-listen = "0.0.0.0:8080"          # PORT env overrides the port
+listen = "127.0.0.1:8080"        # default; `mode = none` is refused unless this is loopback. Public bind: 0.0.0.0 with token/oidc.
 http2 = true                      # HTTP/2 (h2c when TLS is off, ALPN when on)
 max_concurrent_requests = 512     # global cap on in-flight git requests
 max_concurrent_per_repo = 64      # per-repo cap (upload-pack / receive-pack)
@@ -39,15 +39,17 @@ mode = "off"                      # "off" (HTTP/1.1 + h2c) | "self_signed" (gene
 
 [server.auth]
 mode = "none"                     # "none" | "token" | "oidc"
-                                  #   none  — everyone is `anon` with write (loopback experiments)
+                                  #   none  — everyone is `anon` with write+admin; loopback listen only
                                   #   token — static `tokens` below, as `Authorization: Bearer` or the password of HTTP Basic
                                   #   oidc  — any OpenID Connect issuer: browser sign-in through it, ID tokens as bearers,
                                   #           walgit-issued access tokens for git (/_auth/tokens), plus `tokens` for robots
 anonymous_read = true             # must be false in oidc mode
 # tokens = [                      # token → principal; `token_env` reads the value from the environment at startup
-#   { principal = "alice", token_env = "WALGIT_TOKEN_ALICE", write = true },
+#   { principal = "alice", token_env = "WALGIT_TOKEN_ALICE", write = true, admin = true },
 #   { principal = "ci", token = "literal-secret", write = false },
 # ]
+# admin_emails = []                # oidc: emails that may PUT/DELETE settings and policy.json
+# admin_domains = []               # oidc: email domains that may PUT/DELETE settings and policy.json
 # issuer = "https://id.example.com"        # oidc: discovery at <issuer>/.well-known/openid-configuration
 # allowed_domains = ["example.com"]        # oidc: email domains admitted (email_verified required)
 # allowed_emails = []                      # oidc: individual identities admitted

--- a/web/API.md
+++ b/web/API.md
@@ -270,9 +270,11 @@ host's config (`effective config`).
 `GET` → `{revision, author, updated_at, message, toml}` (`revision: 0` = none). `PUT` body = the TOML
 (`?message=` optional), validated against the serving host's build — 400 with the reason and nothing published
 on failure; 200 `{revision}`. `DELETE` publishes an empty document. `GET …/settings/effective` → the effective
-config as TOML (`application/toml`); `GET …/settings/history` → `{min_seq, entries:[{seq,revision,author,message,
-at,toml}]}` from the live log (older changes are folded into checkpoints). All `no-store`; write needs write
-access. Every instance sees a new revision on its next refs-level sync (no extra round trip: the document rides
+`[bundles]`/`[maintenance]`/`[compaction]`/`[upstream]` as TOML (`application/toml`; no host secrets,
+no `token_env`); `GET …/settings/history` → `{min_seq, entries:[{seq,revision,author,message,
+at,toml}]}` from the live log (older changes are folded into checkpoints). All `no-store`; PUT/DELETE need
+**admin** (`tokens[].admin` or oidc `admin_emails`/`admin_domains`; `mode = none` is admin on loopback).
+Every instance sees a new revision on its next refs-level sync (no extra round trip: the document rides
 inline on `manifest.pb`). CLI: `walgit repo settings show|set|clear|history`.
 
 Settings tab helpers (`/{o}/{r}/api/settings…`, all `no-store`): `GET …/settings/describe` → `{settings, sections,


### PR DESCRIPTION
> This pull request was posted by Grok Build using grok-4.6 on behalf of David.

Closes the six confirmed High/Critical issues from a first-pass review of this repo, plus three serving-runtime stalls (full pack-index remmap on every ref write, gix `refresh()` on the request worker after each fault round, remote `.idx` download on the tokio serving runtime).

## Security

- **`GET …/settings/effective` no longer dumps the host Config.** Readers get `[bundles]` / `[maintenance]` / `[compaction]` / `[upstream]` only. `upstream.token_env` is omitted (host-only). `GET …/settings/describe` no longer flattens the env-var name into `fields`.
- **Write is not admin.** `PUT`/`DELETE` of settings and of `policy.json` require an admin principal: `tokens[].admin`, or OIDC `admin_emails` / `admin_domains`. `mode = none` is admin on loopback. `upstream.token_env` is rejected in repo settings so a pusher cannot name an arbitrary host env var for LFS/git follow.
- **Ref-name injection.** Receive-pack and `apply_ref_txn` / offline WAL replay reject newlines, NULs, and git-illegal names/oids before they are interpolated into `git update-ref --stdin`. Symbolic updates write `HEAD`, not `path.join(name)`.
- **LFS PUT no longer `read_to_end`s then checks the cap** (default 16 GiB). Streamed to a tempfile with a running byte count; oid must be 64 hex before `lfs_key` (which no longer panics on short strings).
- **`auth.mode = none` is loopback-only.** `Config::validate` fails on a public bind. Default `server.listen` is `127.0.0.1:8080`.
- **`accel-redirect` is honoured only for loopback peers** (the nginx example talks to `127.0.0.1`). A client on a public bind cannot spoof `X-Walgit-Capabilities` and steal `X-Walgit-Store-Authorization`.

## Runtime

- `refresh_refs()` remmaps refs without loading pack indexes. Ref-only writers (`apply_ref_txn`, `load_ref_snapshot`, `pack_refs`) use it. Pack installs still `refresh()`.
- gix fault rounds use `refresh_async()`.
- `RemotePacks::open` runs on the bulk runtime.

## Tests run

`cargo test -p walgit-config` — pass.

Proto-dependent crates (`walgit-git`, `walgit-server`, `walgit-wal`) were not compiled here: `protoc` was not on PATH.

## Deliberate non-work

- Did not add an admin bit to issued `wgt_…` tokens beyond the email/domain lists (OIDC admin is `admin_emails` / `admin_domains`; static tokens use `admin = true`).
- Did not fix remaining review items: cond-GET single-flight, extra `bundles/list.pb` GET on v2 advert, S3 D19 split, `evict_idle` not scheduled, S3 CAS ABA, OIDC nonce/PKCE, markdown URL sanitizer.