### PR TITLE
Fix the build, repair the local gates, add CI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,32 @@
 [build]
 target-dir = "target"
+
+# Hermetic git for everything cargo spawns.
+#
+# Tests across walgit-bundle, walgit-cli, walgit-git and walgit-wal run `git init` / `git commit`
+# in temp repos without sandboxing git config, so they inherit the developer's. A contributor with
+# commit.gpgsign set gets "gpg failed to sign the data: No secret key" on ~30 tests — green on a
+# bare CI runner, red on a signing laptop, which is the worse way round: CI cannot see it.
+#
+# GIT_CONFIG_GLOBAL does not disable a setting, it replaces the path git reads global config from.
+# Pointed at /dev/null, ~/.gitconfig is never opened, so its include.path chain is never followed
+# either — which is where a signing flag often hides, several files deep. Nulling the config also
+# drops user.name and user.email, hence the fixed identity below. tests/lib-auth.sh already does
+# this for the shell suite.
+#
+# Scope is deliberately wider than tests: [env] covers every process cargo launches, so
+# `cargo run -p walgit-server` also gets a neutered global config. That is wanted — a server
+# spawning index-pack and repack should not inherit a laptop's hooks, aliases, gc.auto or
+# fsmonitor — but it is not "tests only". The scoped alternative is .env() on each git-spawning
+# helper across four crates: no blast radius, ~40 lines of duplication, and every new test that
+# spawns git has to remember. One place won.
+#
+# `force` stays at its default (false), so a value already exported still wins. Unix-only
+# (/dev/null); a Windows host would need NUL.
+[env]
+GIT_CONFIG_GLOBAL = "/dev/null"
+GIT_CONFIG_SYSTEM = "/dev/null"
+GIT_AUTHOR_NAME = "walgit tests"
+GIT_AUTHOR_EMAIL = "tests@walgit.test"
+GIT_COMMITTER_NAME = "walgit tests"
+GIT_COMMITTER_EMAIL = "tests@walgit.test"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,82 @@
+name: CI
+
+# The repository had no build/test workflow: only pages.yml (a site deploy). A workspace that did
+# not compile reached main because nothing ran cargo on push. This runs `just ci` — the same three
+# tiers AGENTS.md documents (warnings, test, e2e) — so CI and a contributor's laptop cannot drift.
+# The tier definitions live in the justfile, never duplicated here.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-test:
+    name: warnings + test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # prost-build does not vendor protoc; without it the proto crate fails with NotFound.
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      # No toolchain version here on purpose: rust-toolchain.toml pins it (and its components).
+      # `rustup show` installs exactly that, so the pin has one home.
+      - name: Install the pinned Rust toolchain
+        run: rustup show && cargo --version && git --version
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: web/pnpm-lock.yaml
+
+      # Required, not cosmetic: build.rs only writes a placeholder index.html, and api_v1's
+      # v1_surface_and_browser_lane asserts /repos.js and /repos.mjs are served 200. Also runs
+      # oxlint --deny-warnings and tsc --noEmit, so the web gate is covered here too.
+      - name: Build the SPA and the SDK
+        run: just web-build
+
+      - run: just warnings
+      - run: just test
+
+  e2e:
+    name: e2e
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - name: Install the pinned Rust toolchain
+        run: rustup show && cargo --version && git --version
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: web/pnpm-lock.yaml
+      - name: Build the SPA and the SDK
+        run: just web-build
+      - run: just e2e

--- a/crates/walgit-git/tests/receive.rs
+++ b/crates/walgit-git/tests/receive.rs
@@ -67,7 +67,11 @@ async fn parse_receive_rejects_newline_in_ref_name() {
     let line = format!("{zero} {new} refs/heads/foo\nupdate refs/heads/main {new}");
     encode_data(&mut body, line.as_bytes());
     encode_flush(&mut body);
-    let err = receive::parse(&body[..]).await.unwrap_err().to_string();
+    // Not `.unwrap_err()`: the Ok tuple holds a PrefixedReader, which is not Debug.
+    let err = match receive::parse(&body[..]).await {
+        Ok(_) => panic!("expected parse to reject the ref name"),
+        Err(e) => e.to_string(),
+    };
     assert!(err.contains("invalid ref name"), "{err}");
 }
 

--- a/crates/walgit-git/tests/upload_gix_scale.rs
+++ b/crates/walgit-git/tests/upload_gix_scale.rs
@@ -31,7 +31,14 @@ mod cm {
 fn max_rss_kb() -> u64 {
     let mut ru: libc::rusage = unsafe { std::mem::zeroed() };
     unsafe { libc::getrusage(libc::RUSAGE_SELF, &mut ru) };
-    ru.ru_maxrss as u64
+    // getrusage reports ru_maxrss in KB on Linux but in BYTES on macOS/BSD.
+    // Without this, the memory-bound assertion reads 1024x high on macOS and
+    // fails a passing result (a 16 MB delta shown as "16832 MB").
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    let kb = (ru.ru_maxrss as u64) / 1024;
+    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+    let kb = ru.ru_maxrss as u64;
+    kb
 }
 
 /// Deterministic source via `git fast-import`: `commits` commits, each rewriting `files_per_commit`

--- a/crates/walgit-server/Cargo.toml
+++ b/crates/walgit-server/Cargo.toml
@@ -64,7 +64,7 @@ rustls.workspace = true
 rustls-pemfile.workspace = true
 rcgen.workspace = true
 tokio-rustls.workspace = true
-[dev-dependencies]
 tempfile.workspace = true
+[dev-dependencies]
 reqwest.workspace = true
 rcgen = { workspace = true, features = ["x509-parser"] }

--- a/crates/walgit-server/src/lib.rs
+++ b/crates/walgit-server/src/lib.rs
@@ -483,9 +483,8 @@ fn loopback_twin(addr: std::net::SocketAddr) -> Option<std::net::SocketAddr> {
     }
 }
 
-/// TCP listener that enables low-latency writes on every accepted connection.
-/// Git's receive-pack status consists of many pkt-lines; leaving Nagle enabled
-/// can turn those writes into tens of seconds of delayed-ACK stalls.
+/// axum `Listener` over [`TcpAccept`] (the dual-stack loopback binder). Nagle
+/// is disabled per-connection via `.tap_io(set_nodelay)` at the serve site.
 struct NodelayListener(TcpAccept);
 
 impl axum::serve::Listener for NodelayListener {
@@ -495,12 +494,7 @@ impl axum::serve::Listener for NodelayListener {
     async fn accept(&mut self) -> (Self::Io, Self::Addr) {
         loop {
             match self.0.accept().await {
-                Ok((stream, addr)) => {
-                    if let Err(e) = stream.set_nodelay(true) {
-                        tracing::debug!(error = ?e, %addr, "failed to set TCP_NODELAY");
-                    }
-                    return (stream, addr);
-                }
+                Ok((stream, addr)) => return (stream, addr),
                 Err(e) => {
                     tracing::warn!(error = ?e, "TCP accept failed");
                 }
@@ -510,6 +504,17 @@ impl axum::serve::Listener for NodelayListener {
 
     fn local_addr(&self) -> std::io::Result<Self::Addr> {
         self.0.local_addr()
+    }
+}
+
+/// Enable TCP_NODELAY on an accepted stream. Applied via `Listener::tap_io` so
+/// the connection stays a plain `TcpStream` and axum's blanket `Connected` impl
+/// for `TapIo` supplies the peer `SocketAddr` to `ConnectInfo` (used by the
+/// accel-redirect loopback check). Git's receive-pack status is many small
+/// pkt-lines; leaving Nagle on turns those into delayed-ACK stalls.
+fn set_nodelay(stream: &mut tokio::net::TcpStream) {
+    if let Err(e) = stream.set_nodelay(true) {
+        tracing::debug!(error = ?e, "failed to set TCP_NODELAY");
     }
 }
 
@@ -580,8 +585,9 @@ pub async fn serve(
                 .await
             }
             None => {
+                use axum::serve::ListenerExt;
                 axum::serve(
-                    NodelayListener(listener),
+                    NodelayListener(listener).tap_io(set_nodelay),
                     app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
                 )
                 .with_graceful_shutdown(graceful)

--- a/justfile
+++ b/justfile
@@ -1,5 +1,13 @@
 # walgit justfile — local dev and test targets.
 
+# `timeout` is GNU coreutils: absent on macOS, where every wrapped recipe otherwise dies with
+# `sh: timeout: command not found` (exit 127) before a single test runs — pushing contributors
+# onto the broad `cargo test --workspace` that AGENTS.md forbids. Prefer timeout, then gtimeout
+# (brew install coreutils), else run unwrapped: no watchdog is better than no tests.
+t5 := `if command -v timeout >/dev/null 2>&1; then echo "timeout 300"; elif command -v gtimeout >/dev/null 2>&1; then echo "gtimeout 300"; else echo ""; fi`
+t10 := `if command -v timeout >/dev/null 2>&1; then echo "timeout 600"; elif command -v gtimeout >/dev/null 2>&1; then echo "gtimeout 600"; else echo ""; fi`
+t15 := `if command -v timeout >/dev/null 2>&1; then echo "timeout 900"; elif command -v gtimeout >/dev/null 2>&1; then echo "gtimeout 900"; else echo ""; fi`
+
 # Default: show available targets.
 default:
     @just --list
@@ -73,13 +81,13 @@ dev-store-stop:
 # Never run `cargo test --workspace --no-fail-fast` interactively: a single
 # hung test blocks for the whole timeout. Use `just e2e` / `just ci` below.
 test:
-    timeout 300 cargo test --workspace --lib --bins
-    timeout 300 cargo test -p walgit-store -p walgit-git -p walgit-wal -p walgit-bundle --tests
-    timeout 300 cargo test -p walgit-server --test web_api --test web_ui --test api_v1 --test static_http --test maintain --test routing_prefix --test lfs_upstream --test drain
+    {{t5}} cargo test --workspace --lib --bins
+    {{t5}} cargo test -p walgit-store -p walgit-git -p walgit-wal -p walgit-bundle --tests
+    {{t5}} cargo test -p walgit-server --test web_api --test web_ui --test api_v1 --test static_http --test maintain --test routing_prefix --test lfs_upstream --test drain
 
 # Smart-HTTP end-to-end against real git (≈ 20 s) — run when touching smart.rs/receive/upload-pack/wal.
 e2e *ARGS:
-    timeout 600 cargo test -p walgit-server --test e2e {{ARGS}}
+    {{t10}} cargo test -p walgit-server --test e2e {{ARGS}}
 
 # Zero rustc warnings, workspace-wide, all targets (tests, benches, examples).
 # Done by grepping the normal build instead of RUSTFLAGS=-D warnings, which would
@@ -87,7 +95,13 @@ e2e *ARGS:
 warnings:
     #!/usr/bin/env bash
     set -uo pipefail
-    out="$(timeout 900 cargo build --workspace --all-targets 2>&1)"
+    # A command substitution that fails does NOT abort under `set -uo pipefail` (no -e), so a
+    # workspace that does not compile used to fall through to "no rustc warnings" and exit 0 —
+    # the preflight passing on a broken tree. Check the build's status before grepping it.
+    if ! out="$({{t15}} cargo build --workspace --all-targets 2>&1)"; then
+        printf '%s\n' "$out"
+        echo; echo "cargo build failed — fix the errors above"; exit 1
+    fi
     if printf '%s\n' "$out" | grep -qE '^warning: (unused|function|variable|field|method|struct|enum|never|dead|irrefutable|unreachable|value assigned|deprecated|trait|type|constant|static|associated)'; then
         printf '%s\n' "$out" | grep -E '^warning' -A4 | grep -vE '^warning: `walgit-[a-z]+`'
         echo; echo "rustc warnings present — fix them (just warnings is part of just ci and the deploy preflight)"; exit 1


### PR DESCRIPTION
`main` has not compiled since #2 merged. This fixes the build, repairs the local gates that should have caught it, and adds the CI that was never there. Why it wasn't caught...

- **There was no CI.** `.github/workflows/` contained only `pages.yml`, a site deploy triggered by `site/**`. Nothing ran `cargo build` on push or PR. `just ci` existed and was well shaped; nothing invoked it.
- **Local preflight lied.** `just warnings` captured `cargo build` output in a command substitution under `set -uo pipefail` — no `-e` — so a failed build did not abort the recipe. Execution fell through to the grep, found no `^warning:` lines in the compiler's *errors*, printed `no rustc warnings` and exited 0. Run against `main` today:
- **On macOS the test suite could not run at all.** Every recipe wraps cargo in `timeout`, which is GNU coreutils and is not installed on macOS:

```
$ just test
sh: timeout: command not found
error: Recipe `test` failed on line 76 with exit code 127
```

So `just test`, `just e2e` and `just ci` — the entry points `AGENTS.md` documents — are unusable on a Mac. The only thing left that works is `cargo test --workspace`, which is precisely the command `AGENTS.md:441` says never to run, and which drags in `sim`, `events`, `follow` and `policy`. That path then trips a third trap: ~30 tests spawn `git commit` without sandboxing git config, so anyone with `commit.gpgsign` set gets `gpg failed to sign the data: No secret key`.

Broken gate → forbidden fallback → unrelated failures. That chain is the actual bug.

## What's in here

Five commits, each one idea.

**`8903895` Fix the workspace build broken in be65af1** — three breaks from the same PR. `tempfile` was used in `lfs.rs` (library code) while only a dev-dependency. `NodelayListener` stopped satisfying axum's `Connected` bound after the switch to `into_make_service_with_connect_info`, cascading into "`WithGracefulShutdown` is not a future"; a hand-written impl is refused by the orphan rule (E0117 — the local type is *covered* by the foreign `IncomingStream`), so Nagle is now disabled through `Listener::tap_io` and the blanket `TapIo` impl supplies `ConnectInfo`. Behaviour unchanged. Third: a `walgit-git` test called `unwrap_err()` on a `Result` whose `Ok` holds a non-`Debug` `PrefixedReader` — only `--all-targets` reaches it, which is why `cargo check -p walgit-server` misses it.

**`daddc27` Make the justfile's gates actually gate** — resolve the timeout wrapper once (`timeout`, else `gtimeout`, else unwrapped: no watchdog beats no tests), and make `just warnings` check the build's exit status before grepping its output.

**`852805a` Isolate the tests from the developer's git config** — `GIT_CONFIG_GLOBAL` does not disable a setting, it replaces the *path* git reads global config from; pointed at `/dev/null`, `~/.gitconfig` is never opened and its `include.path` chain is never followed, which is where a signing flag usually hides. Done through cargo's `[env]`, which covers every test binary from one place rather than patching each git-spawning helper across four crates. Note this is deliberately wider than tests: `cargo run -p walgit-server` also gets a neutered global config, which is arguably correct for a process that spawns `index-pack`/`repack`. Rationale and the rejected alternative are recorded in the commit and in the file.

**`8af5a74` Fix the RSS bound on macOS** — `getrusage` reports `ru_maxrss` in kilobytes on Linux but in **bytes** on macOS/BSD, so the D2 thin-pack memory guard read 1024× high and failed a passing result: a 16 MB delta reported as `max RSS grew 16832 MB (bound 374 MB)`. Red on every Mac, green in CI, which trains people to ignore the one test guarding a 178 GB OOM regression.

**`aa9b5a4` Add a CI workflow** — runs the documented tiers *through `just`*, so CI and a contributor's laptop cannot drift and the tier definitions keep one home in the justfile. Three notes: `protoc` is installed explicitly because prost-build does not vendor it; the toolchain version is deliberately not restated because `rustup show` honours `rust-toolchain.toml`; and the SPA/SDK are built before the tests because `build.rs` only writes a placeholder `index.html` while `api_v1`'s `v1_surface_and_browser_lane` asserts `/repos.js` and `/repos.mjs` serve 200. That step also runs `oxlint --deny-warnings` and `tsc --noEmit`, so the web gate comes along for free.