### PR TITLE
feat(store): add Azure Blob backend and AKS identity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,8 +144,8 @@ machines whose "disk" is 20 GiB of tmpfs, next to a long tail of small repositor
 | `fsck.pb` | Last connectivity audit (`FsckReport`), written by the maintainer's `fsck` unit, consumed by `repair` (`docs/INTEGRITY.md`). |
 | `events/cursor.json` | Durable acknowledged WAL sequence of the events bridge; advanced only after the webhook acknowledged (D32). |
 | `lfs/objects/<aa>/<bb>/<oid>` | LFS objects (sha256-addressed, immutable). Missing ones can be read through from `upstream.lfs` and persisted (`docs/LFS.md`). |
-Schema `crates/walgit-proto/proto/walgit/v1/wal.proto`; GCS over gRPC, S3 (AWS SDK) and in-memory stores share
-one contract suite (`crates/walgit-store/tests/contract.rs`, incl. compose).
+Schema `crates/walgit-proto/proto/walgit/v1/wal.proto`; GCS, S3, Azure Blob and in-memory stores share one
+contract suite (`crates/walgit-store/tests/contract.rs`, incl. compose).
 
 ### 2.2 Write path
 receive-pack (ours, `walgit-git/src/receive.rs`) → index the pack locally (`git index-pack --stdin --fix-thin
@@ -399,6 +399,17 @@ decision in §4 — or the PR is; never "fix later".
   + chain) is for clones, **`bundles/catchup`** (no fulls) is what recipes record in `fetch.bundleURI`. Measured: a
   catch-up is exactly the slots missed; for a client fetching several times a day, upload-pack's thin pack is
   smaller than an hourly bundle — bundles pay off for fresh clones and far-behind clients.
+- **D42** **Azure Blob Storage is a first-class ObjectStore backend** (2026-08-23), alongside S3 and GCS.
+  `store.backend = "azure"`; the container is `store.bucket`. Credentials come from env — account key
+  (`store.azure.account_key_env`, default `AZURE_STORAGE_ACCOUNT_KEY`), connection string
+  (`store.azure.connection_string_env`), or Microsoft Entra ID (`store.azure.use_aad`: AKS workload identity,
+  managed identity, then developer tools). The endpoint is empty for
+  `https://{account}.blob.core.windows.net`, or `http://127.0.0.1:10000` for Azurite. Version
+  tokens are blob ETags (opaque, quotes stripped). Compose is Put Block From URL + Put Block List
+  (`supports_compose = true`, `compose_is_native = false`); `signed_get_url` / `accel_target` mint a
+  service SAS (account key) or user-delegation SAS (Entra). The Blob REST API is used directly: the
+  official `azure_storage_blob` 1.x client is TokenCredential-only and cannot sign Azurite/account-key
+  requests. Local bar: `just test-azure` against Azurite.
 
 Decision identifiers are stable; gaps in the numbering are intentional.
 
@@ -423,8 +434,9 @@ Decision identifiers are stable; gaps in the numbering are intentional.
 - **Standalone first (D39):** a feature must work with walgit hit directly (no edge, in-process TLS, bytes
   streamed by walgit). Anything an edge takes over is announced per request in `X-Walgit-Capabilities`; never
   infer an edge from config, never hardcode a hostname in `crates/` or `web/`.
-- **S3 and GCS are both first class.** Every store feature has both implementations and runs in the contract
-  suite (`just test-s3` against rustfs, `just test-gcs <bucket>`); "GCS only" is a bug.
+- **S3, GCS and Azure Blob are all first class.** Every store feature has all three implementations and
+  runs in the contract suite (`just test-s3` against rustfs, `just test-gcs <bucket>`, `just test-azure`
+  against Azurite); "GCS only" (or any single-backend path) is a bug.
 - **Use the rig before prod** (`just dev-store` → `walgit-server --config walgit.standalone.toml`). Per-repo
   settings (D24) with minute-scale slots compress a week of bundle behaviour into 30 minutes.
 - No new auth paths (§1.3). No LIST on hot paths. No unbounded buffering of packs in memory. No full

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,6 +753,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "azure_core"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e41cbd819986ba41904c207d8ffc4106f8f8352a548d773e9554906379bb2fb"
+dependencies = [
+ "async-lock",
+ "async-trait",
+ "azure_core_macros",
+ "bytes",
+ "futures",
+ "pin-project",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "typespec",
+ "typespec_client_core",
+]
+
+[[package]]
+name = "azure_core_macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9b52dba6a345f3ad2d42ff8d0d63df9d0994cfa29657bf18ffdbf149f78a4f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "tracing",
+]
+
+[[package]]
+name = "azure_identity"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32edf96b356ca7c51d7590c4925cc36efc3947a5da4468e8e0b25c56ecbb3de5"
+dependencies = [
+ "async-lock",
+ "async-trait",
+ "azure_core",
+ "futures",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "time",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5674,6 +5725,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "typespec"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "753a2fe021e407d4fc9ee6f4f0a33403cc306d5c54c4e4ebe1b8cbde0ca052b9"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "typespec_client_core"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0373af0f9d4f580b3a1a9d9639cedaabe015ed262b35bfbe13941bfb14fe1ea6"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "dyn-clone",
+ "futures",
+ "pin-project",
+ "rand 0.10.2",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "time",
+ "tokio",
+ "tracing",
+ "typespec",
+ "typespec_macros",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "typespec_macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c608f4427943f8adb211abc95c87672b1b98847152783507d54e3246e502f60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "uluru"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5979,13 +6081,18 @@ dependencies = [
  "aws-sdk-s3",
  "aws-smithy-types",
  "axum",
+ "azure_core",
+ "azure_identity",
+ "base64",
  "bytes",
  "bytesize",
+ "chrono",
  "futures",
  "google-cloud-auth",
  "google-cloud-gax",
  "google-cloud-storage",
  "hex",
+ "hmac 0.12.1",
  "http 1.5.0",
  "metrics",
  "parking_lot",
@@ -5995,6 +6102,7 @@ dependencies = [
  "rustls 0.23.43",
  "serde",
  "sha1 0.10.7",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,8 @@ google-cloud-auth = "1"
 aws-config = { version = "1", features = ["behavior-version-latest"] }
 aws-sdk-s3 = "1"
 aws-smithy-types = "1"
+azure_identity = "1"
+azure_core = "1"
 clap = { version = "4", features = ["derive", "env"] }
 rand = "0.9"
 sha1 = "0.10"

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # walgit — a git server that is one binary in front of an object store
 
 walgit hosts git repositories with **no database, no leader and no local state that matters**. You run a
-single binary, point it at an S3 or GCS bucket, and you have: smart HTTP (v0/v2) fetch and push, `bundle-uri`
+single binary, point it at an S3, GCS or Azure Blob bucket, and you have: smart HTTP (v0/v2) fetch and push, `bundle-uri`
 clones served as static files, Git LFS, a browsing web UI, a JSON API with an SDK, per-repository push policy,
 webhooks — and a server that scales to repositories **larger than the machine it runs on**. Every machine that
 runs walgit is a disposable cache; the bucket is the repository.
 
 ```sh
-# 1. a bucket (any S3-compatible store or GCS) and a config
+# 1. a bucket (any S3-compatible store, GCS, or Azure Blob) and a config
 cat > walgit.toml <<'EOF'
 [server]
 listen = "0.0.0.0:8080"
@@ -76,7 +76,7 @@ server entirely (**bundle-uri**: fresh clones and catch-ups are static files the
 | **web UI + API** | A React UI (tree, blob, commits, diffs, the WAL's own health page) on a read-mostly JSON API under `/{owner}/{repo}/api/*`; sha-addressed answers are immutable and cached everywhere; long answers stream progress as SSE. `repos.js` is a dependency-free SDK for pages, agents and scripts. |
 | **policy** | Per-repository push rules (`policy.json`): protected refs, groups, fast-forward only, bypass lists. `docs/POLICY.md`. |
 | **settings** | Per-repository config (bundle schedules, compaction, upstream follow) published into the WAL with history. |
-| **events** | A small bridge tails the WAL and POSTs ref events to a webhook, exactly-once per (repo, seq, ref) with a durable cursor. `docs/EVENTS.md`. |
+| **stores** | S3 and S3-compatible (AWS, MinIO, rustfs, R2, Ceph, …), GCS, and Azure Blob Storage, first class; an in-memory store for tests. |
 | **maintenance** | Checkpoints, bundle builds, geometric compaction, base rebuilds, connectivity audits and repairs — one loop that computes the desired state from (config, WAL) every pass and does one bounded unit of the most important missing work. Self-healing by construction: an outage leaves no holes; a deleted artefact is "missing" and rebuilt identically. |
 | **auth** | `none` (loopback), `token` (static tokens), `oidc` (any OpenID Connect issuer: browser sign-in, ID tokens, and walgit-issued access tokens for git). `/services/public/install.sh` sets a developer's machine up in one idempotent command. |
 | **stores** | S3 and S3-compatible (AWS, MinIO, rustfs, R2, Ceph, …) and GCS, first class; an in-memory store for tests. |
@@ -130,11 +130,15 @@ open https://walgit.localhost:8080/
 * `Containerfile`, `flake.nix` — an OCI image and a Nix package/devshell.
 * `deploy/nginx.conf.example` — an optional nginx in front: public TLS, one `auth_request` per credential, and
   **byte offload**: walgit answers bundle/LFS downloads with `X-Accel-Redirect` and nginx streams + caches the
-  object from the bucket itself (S3 presigned or GCS with walgit's bearer). The file documents the contract.
+  object from the bucket itself (S3/Azure presigned URL or GCS bearer). The file documents the contract.
 
 Roles (`server.roles`): `serve` (git, API, UI, bundles, LFS), `maintain` (checkpoints, bundles, compaction,
 fsck/repair), `events` (the webhook bridge). Empty = all. Any number of `serve` hosts may point at one bucket; give
 each repository one maintainer (placement globs) and you are done.
+
+For Azure Blob Storage, set `store.backend = "azure"` and use `store.bucket` as the container. Account-key and
+connection-string credentials are read from the environment. With `store.azure.use_aad = true`, walgit tries AKS
+workload identity first, then managed identity and developer tools; no Azure credential is stored in the config.
 
 ### Authentication
 
@@ -158,6 +162,7 @@ just warnings      # zero rustc warnings across all targets
 just ci            # all of the above
 cargo test -p walgit-server --test sim     # fault-injection simulation (crashes, partitions, stale reads)
 just test-s3       # store contract against local rustfs
+just test-azure    # store contract against local Azurite
 ```
 
 Code map:
@@ -165,7 +170,7 @@ Code map:
 ```
 crates/
   walgit-proto    protobuf schema (wal.proto), log framing, store keys
-  walgit-store    ObjectStore trait (CAS versions, conditional GET, range, compose); backends s3, gcs, memory; leases
+  walgit-store    ObjectStore trait (CAS versions, conditional GET, range, compose); backends s3, gcs, azure, memory; leases
   walgit-git      bare repos on disk, receive-pack, pack ingest, refs ↔ packed-refs, advertisements, upload-pack drivers
   walgit-wal      RepoHandle: sync levels, publish (group commit + CAS), checkpoints, log reader, remote reader, tasks
   walgit-bundle   bundle-uri: slots and chains, building, header ∘ pack composition, lists, retention

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,4 +1,4 @@
-# compose file for walgit local dev (podman compose): rustfs (S3-compatible) + bucket creation.
+# compose file for walgit local dev (podman compose): rustfs (S3-compatible) + Azurite (Azure Blob) + bucket creation.
 #
 # Usage:
 #   podman compose up -d rustfs           # start rustfs
@@ -28,6 +28,14 @@ services:
       timeout: 3s
       retries: 10
 
+  azurite:
+    image: mcr.microsoft.com/azure-storage/azurite
+    command: ["azurite-blob", "--blobHost", "0.0.0.0", "--blobPort", "10000", "--skipApiVersionCheck"]
+    ports:
+      - "10000:10000"
+    volumes:
+      - azurite-data:/data
+
   # One-shot: create the walgit-test bucket after rustfs is healthy.
   create-bucket:
     image: amazon/aws-cli:latest
@@ -48,3 +56,4 @@ services:
 
 volumes:
   rustfs-data:
+  azurite-data:

--- a/crates/walgit-cli/Cargo.toml
+++ b/crates/walgit-cli/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/bin/walgit-server.rs"
 
 [dependencies]
 walgit-proto.workspace = true
-walgit-store.workspace = true
+walgit-store = { workspace = true, features = ["azure"] }
 walgit-config.workspace = true
 walgit-git.workspace = true
 walgit-wal.workspace = true

--- a/crates/walgit-config/src/lib.rs
+++ b/crates/walgit-config/src/lib.rs
@@ -228,6 +228,7 @@ pub struct StoreConfig {
     pub prefix: String,
     pub gcs: GcsConfig,
     pub s3: S3Config,
+    pub azure: AzureConfig,
     pub max_retries: u32,
     /// Objects larger than this use resumable/multipart upload.
     pub multipart_threshold: ByteSize,
@@ -240,6 +241,8 @@ pub enum StoreBackend {
     #[default]
     Gcs,
     S3,
+    /// Azure Blob Storage (Azurite locally, `*.blob.core.windows.net` in Azure).
+    Azure,
     /// Tests only.
     Memory,
 }
@@ -278,6 +281,25 @@ pub struct S3Config {
     pub access_key_env: String,
     pub secret_key_env: String,
     pub force_path_style: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct AzureConfig {
+    /// Blob endpoint. Empty = `https://{account}.blob.core.windows.net`.
+    /// Azurite: `http://127.0.0.1:10000`.
+    pub endpoint: String,
+    /// Storage account name. Azurite: `devstoreaccount1`.
+    pub account: String,
+    /// Env var holding the account key (Shared Key). Unset = not used.
+    pub account_key_env: String,
+    /// Env var holding a connection string (`AccountName`/`AccountKey`/`BlobEndpoint`).
+    /// When that var is set it wins over `account` / `account_key_env` / `endpoint`.
+    pub connection_string_env: String,
+    /// Use Microsoft Entra ID. Credential resolution tries AKS workload
+    /// identity, managed identity, then developer tools.
+    /// Account key is required for Azurite.
+    pub use_aad: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1078,6 +1100,7 @@ impl Default for StoreConfig {
             prefix: String::new(),
             gcs: GcsConfig::default(),
             s3: S3Config::default(),
+            azure: AzureConfig::default(),
             max_retries: 8,
             multipart_threshold: ByteSize::mib(64),
             multipart_part_size: ByteSize::mib(32),
@@ -1103,6 +1126,17 @@ impl Default for S3Config {
             access_key_env: "AWS_ACCESS_KEY_ID".into(),
             secret_key_env: "AWS_SECRET_ACCESS_KEY".into(),
             force_path_style: true,
+        }
+    }
+}
+impl Default for AzureConfig {
+    fn default() -> Self {
+        AzureConfig {
+            endpoint: String::new(),
+            account: String::new(),
+            account_key_env: "AZURE_STORAGE_ACCOUNT_KEY".into(),
+            connection_string_env: "AZURE_STORAGE_CONNECTION_STRING".into(),
+            use_aad: false,
         }
     }
 }
@@ -1383,6 +1417,19 @@ impl Config {
     pub fn validate(&self) -> Result<()> {
         anyhow::ensure!(!self.store.bucket.is_empty(), "store.bucket must be set");
         let t = &self.server.tls;
+        if self.store.backend == StoreBackend::Azure {
+            let azure = &self.store.azure;
+            anyhow::ensure!(
+                !azure.account.is_empty() || !azure.connection_string_env.is_empty(),
+                "store.azure.account or store.azure.connection_string_env must be set"
+            );
+            anyhow::ensure!(
+                azure.use_aad
+                    || !azure.account_key_env.is_empty()
+                    || !azure.connection_string_env.is_empty(),
+                "Azure credentials require store.azure.use_aad, store.azure.account_key_env, or store.azure.connection_string_env"
+            );
+        }
         match t.mode {
             TlsMode::Files => anyhow::ensure!(
                 t.cert.is_some() && t.key.is_some(),
@@ -1983,6 +2030,114 @@ schedule = "@daily"
 keep = 3
 "#;
         assert!(Config::parse(text).is_err());
+    }
+
+    #[test]
+    fn azure_backend_from_toml() {
+        let c: Config = toml::from_str(
+            r#"
+[store]
+backend = "azure"
+bucket = "walgit-test"
+[store.azure]
+endpoint = "http://127.0.0.1:10000"
+account = "devstoreaccount1"
+account_key_env = "AZURE_STORAGE_ACCOUNT_KEY"
+connection_string_env = "AZURE_STORAGE_CONNECTION_STRING"
+use_aad = false
+"#,
+        )
+        .unwrap();
+        assert_eq!(c.store.backend, StoreBackend::Azure);
+        assert_eq!(c.store.bucket, "walgit-test");
+        assert_eq!(c.store.azure.endpoint, "http://127.0.0.1:10000");
+        assert_eq!(c.store.azure.account, "devstoreaccount1");
+        assert_eq!(c.store.azure.account_key_env, "AZURE_STORAGE_ACCOUNT_KEY");
+        assert!(!c.store.azure.use_aad);
+    }
+
+    #[test]
+    fn azure_backend_from_env_overrides() {
+        let mut c = Config::default();
+        c.apply_env(
+            vec![
+                ("WALGIT__STORE__BACKEND".to_string(), "azure".to_string()),
+                (
+                    "WALGIT__STORE__AZURE__ENDPOINT".to_string(),
+                    "http://127.0.0.1:10000".to_string(),
+                ),
+                (
+                    "WALGIT__STORE__AZURE__ACCOUNT".to_string(),
+                    "devstoreaccount1".to_string(),
+                ),
+                (
+                    "WALGIT__STORE__AZURE__ACCOUNT_KEY_ENV".to_string(),
+                    "AZURE_STORAGE_ACCOUNT_KEY".to_string(),
+                ),
+                (
+                    "WALGIT__STORE__AZURE__USE_AAD".to_string(),
+                    "true".to_string(),
+                ),
+            ]
+            .into_iter(),
+        )
+        .unwrap();
+        assert_eq!(c.store.backend, StoreBackend::Azure);
+        assert_eq!(c.store.azure.endpoint, "http://127.0.0.1:10000");
+        assert_eq!(c.store.azure.account, "devstoreaccount1");
+        assert_eq!(c.store.azure.account_key_env, "AZURE_STORAGE_ACCOUNT_KEY");
+        assert!(c.store.azure.use_aad);
+    }
+
+    #[test]
+    fn azure_section_denies_unknown_fields() {
+        let err = toml::from_str::<Config>(
+            r#"
+[store.azure]
+not_a_real_key = "nope"
+"#,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(
+            err.contains("unknown field") && err.contains("not_a_real_key"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn azure_validation_accepts_workload_identity() {
+        let mut c = Config::default();
+        c.store.backend = StoreBackend::Azure;
+        c.store.bucket = "walgit".into();
+        c.store.azure.account = "walgitprod".into();
+        c.store.azure.account_key_env.clear();
+        c.store.azure.connection_string_env.clear();
+        c.store.azure.use_aad = true;
+        c.validate().unwrap();
+    }
+
+    #[test]
+    fn azure_validation_requires_account_source() {
+        let mut c = Config::default();
+        c.store.backend = StoreBackend::Azure;
+        c.store.bucket = "walgit".into();
+        c.store.azure.account.clear();
+        c.store.azure.connection_string_env.clear();
+        let err = c.validate().unwrap_err().to_string();
+        assert!(err.contains("store.azure.account"), "{err}");
+    }
+
+    #[test]
+    fn azure_validation_requires_credentials() {
+        let mut c = Config::default();
+        c.store.backend = StoreBackend::Azure;
+        c.store.bucket = "walgit".into();
+        c.store.azure.account = "walgitprod".into();
+        c.store.azure.account_key_env.clear();
+        c.store.azure.connection_string_env.clear();
+        let err = c.validate().unwrap_err().to_string();
+        assert!(err.contains("Azure credentials require"), "{err}");
     }
 }
 

--- a/crates/walgit-store/Cargo.toml
+++ b/crates/walgit-store/Cargo.toml
@@ -5,9 +5,10 @@ edition.workspace = true
 license.workspace = true
 
 [features]
-default = ["gcs", "s3"]
+default = ["gcs", "s3", "azure"]
 gcs = ["dep:google-cloud-storage", "dep:google-cloud-gax", "dep:google-cloud-auth", "dep:reqwest"]
 s3 = ["dep:aws-config", "dep:aws-sdk-s3", "dep:aws-smithy-types", "dep:reqwest"]
+azure = ["dep:reqwest", "dep:hmac", "dep:sha2", "dep:base64", "dep:chrono", "dep:azure_identity", "dep:azure_core"]
 
 [dependencies]
 walgit-proto.workspace = true
@@ -36,6 +37,12 @@ aws-config = { workspace = true, optional = true }
 aws-sdk-s3 = { workspace = true, optional = true }
 aws-smithy-types = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
+hmac = { workspace = true, optional = true }
+sha2 = { workspace = true, optional = true }
+base64 = { workspace = true, optional = true }
+chrono = { workspace = true, optional = true }
+azure_identity = { workspace = true, optional = true }
+azure_core = { workspace = true, optional = true }
 [dev-dependencies]
 axum.workspace = true
 tempfile.workspace = true

--- a/crates/walgit-store/src/azure.rs
+++ b/crates/walgit-store/src/azure.rs
@@ -1,0 +1,1461 @@
+//! Azure Blob Storage backend.
+//!
+//! Speaks the Blob REST API over `reqwest` with Shared Key (HMAC-SHA256) or
+//! Entra ID bearer tokens. `azure_storage_blob` 1.x is TokenCredential-only —
+//! it cannot sign Azurite/account-key requests or mint account SAS — so the
+//! wire protocol lives here rather than behind that client.
+//!
+//! ## Version tokens
+//!
+//! Blob ETags are opaque `Version` strings. Quotes are stripped on read and
+//! re-applied on `If-Match` / `If-None-Match`. Callers never parse them.
+//!
+//! ## Conditional PUT
+//!
+//! `PutMode::Create`    → `If-None-Match: *`
+//! `PutMode::Update(v)` → `If-Match: "<etag>"`
+//! Both 412 and 409 (BlobAlreadyExists) map to `PreconditionFailed`.
+//!
+//! ## Compose
+//!
+//! Put Block From URL (server-side copy of each source, authenticated with a
+//! short SAS) + Put Block List. Small sources may be fetched and Put Block'd
+//! when the emulator reports that From URL is missing. `compose_is_native`
+//! is false: bytes still move inside the account.
+//!
+//! ## URL shape
+//!
+//! Production (`{account}.blob.*`): `https://{account}.blob.core.windows.net/{container}/{key}`.
+//! Azurite / custom endpoint: `{endpoint}/{account}/{container}/{key}`.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use base64::Engine as _;
+use bytes::Bytes;
+use chrono::{SecondsFormat, Utc};
+use futures::StreamExt;
+use hmac::{Hmac, Mac};
+use parking_lot::Mutex;
+use sha2::Sha256;
+
+use crate::{
+    BoxStream, GetOptions, GetResult, ObjectMeta, ObjectStore, PutBody, PutMode, PutOptions,
+    Result, StoreError, Version, util,
+};
+
+const API_VERSION: &str = "2021-12-02";
+const IMMUTABLE_CACHE_CONTROL: &str = "public, max-age=31536000, immutable";
+const WELL_KNOWN_ACCOUNT: &str = "devstoreaccount1";
+const WELL_KNOWN_KEY: &str =
+    "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+/// Put Block From URL max source range (100 MiB is well under the 4000 MiB cap
+/// and keeps Azurite happy).
+const COPY_CHUNK: u64 = 100 * 1024 * 1024;
+
+type HmacSha256 = Hmac<Sha256>;
+
+enum AzureAuth {
+    SharedKey {
+        key: Vec<u8>,
+    },
+    Bearer {
+        workload: Option<Arc<azure_identity::WorkloadIdentityCredential>>,
+        managed: Option<Arc<azure_identity::ManagedIdentityCredential>>,
+        developer: Arc<azure_identity::DeveloperToolsCredential>,
+    },
+}
+
+/// Azure Blob object store.
+pub struct AzureStore {
+    /// Control-plane client (HEAD, small PUT, list, delete, SAS).
+    http: reqwest::Client,
+    /// Bulk client (object GET, large PUT, compose copies) — own pool so a
+    /// multi-GB range read cannot stall a manifest GET (D19).
+    bulk: reqwest::Client,
+    account: String,
+    /// Origin + account-path prefix, no trailing slash.
+    /// Production: `https://acct.blob.core.windows.net`
+    /// Azurite: `http://127.0.0.1:10000/devstoreaccount1`
+    service_url: String,
+    container: String,
+    auth: AzureAuth,
+    /// True when the account name is a path segment (Azurite). Kept so a
+    /// reconstructed list handle matches the live store.
+    #[allow(dead_code)]
+    path_style: bool,
+    multipart_threshold: u64,
+    multipart_part_size: u64,
+    token_cache: Mutex<Option<(String, Instant)>>,
+}
+
+impl AzureStore {
+    /// Build a store from `walgit-config::StoreConfig`.
+    ///
+    /// Credentials: connection string (if that env var is set) wins, then
+    /// account key env, then Entra ID when `use_aad`. Missing creds fail closed.
+    pub async fn new(cfg: &walgit_config::StoreConfig) -> anyhow::Result<Self> {
+        let parsed = resolve_azure(cfg)?;
+        let http = reqwest::Client::builder()
+            .pool_max_idle_per_host(8)
+            .timeout(Duration::from_secs(60))
+            .build()?;
+        let bulk = reqwest::Client::builder()
+            .pool_max_idle_per_host(32)
+            .timeout(Duration::from_secs(3600))
+            .build()?;
+        Ok(AzureStore {
+            http,
+            bulk,
+            account: parsed.account,
+            service_url: parsed.service_url,
+            container: cfg.bucket.clone(),
+            auth: parsed.auth,
+            path_style: parsed.path_style,
+            multipart_threshold: cfg.multipart_threshold.as_u64(),
+            multipart_part_size: cfg.multipart_part_size.as_u64().max(1),
+            token_cache: Mutex::new(None),
+        })
+    }
+
+    /// Create the container if it does not exist (409 = already there).
+    pub async fn ensure_container(&self) -> Result<()> {
+        let url = format!("{}?restype=container", self.container_url());
+        let resp = self
+            .execute(
+                self.http
+                    .put(&url)
+                    .header("content-length", "0")
+                    .body(Bytes::new()),
+                false,
+            )
+            .await?;
+        match resp.status().as_u16() {
+            201 | 202 | 409 => Ok(()),
+            s => {
+                let body = resp.text().await.unwrap_or_default();
+                Err(StoreError::other(anyhow::anyhow!(
+                    "azure create container {s}: {body}"
+                )))
+            }
+        }
+    }
+
+    fn container_url(&self) -> String {
+        format!("{}/{}", self.service_url, self.container)
+    }
+
+    fn object_url(&self, key: &str) -> String {
+        format!("{}/{}", self.container_url(), util::encode_path(key))
+    }
+
+    fn client(&self, bulk: bool) -> &reqwest::Client {
+        if bulk { &self.bulk } else { &self.http }
+    }
+
+    async fn execute(
+        &self,
+        builder: reqwest::RequestBuilder,
+        bulk: bool,
+    ) -> Result<reqwest::Response> {
+        let mut req = builder
+            .build()
+            .map_err(|e| StoreError::other(anyhow::anyhow!("azure build request: {e}")))?;
+        req.headers_mut().insert(
+            "x-ms-version",
+            API_VERSION.parse().expect("api version is ascii"),
+        );
+        if !req.headers().contains_key("x-ms-date") {
+            let date = Utc::now().format("%a, %d %b %Y %H:%M:%S GMT").to_string();
+            req.headers_mut().insert(
+                "x-ms-date",
+                date.parse()
+                    .map_err(|e| StoreError::other(anyhow::anyhow!("azure date header: {e}")))?,
+            );
+        }
+        match &self.auth {
+            AzureAuth::SharedKey { key } => {
+                let auth =
+                    shared_key_auth(&self.account, key, req.method(), req.url(), req.headers())?;
+                req.headers_mut().insert(
+                    reqwest::header::AUTHORIZATION,
+                    auth.parse().map_err(|e| {
+                        StoreError::other(anyhow::anyhow!("azure auth header: {e}"))
+                    })?,
+                );
+            }
+            AzureAuth::Bearer { .. } => {
+                let token = self.bearer_token().await?;
+                req.headers_mut().insert(
+                    reqwest::header::AUTHORIZATION,
+                    format!("Bearer {token}").parse().map_err(|e| {
+                        StoreError::other(anyhow::anyhow!("azure bearer header: {e}"))
+                    })?,
+                );
+            }
+        }
+        self.client(bulk)
+            .execute(req)
+            .await
+            .map_err(|e| StoreError::retryable(anyhow::anyhow!("azure http: {e}")))
+    }
+
+    async fn bearer_token(&self) -> Result<String> {
+        if let Some((tok, exp)) = self.token_cache.lock().as_ref() {
+            if Instant::now() + Duration::from_secs(60) < *exp {
+                return Ok(tok.clone());
+            }
+        }
+        let AzureAuth::Bearer {
+            workload,
+            managed,
+            developer,
+        } = &self.auth
+        else {
+            return Err(StoreError::other(anyhow::anyhow!(
+                "azure: internal: bearer_token without Bearer auth"
+            )));
+        };
+        use azure_core::credentials::TokenCredential;
+        let scopes = ["https://storage.azure.com/.default"];
+        let tok = if let Some(workload) = workload {
+            match workload.get_token(&scopes, None).await {
+                Ok(token) => token,
+                Err(_) => self.managed_or_developer_token(managed, developer, &scopes).await?,
+            }
+        } else {
+            self.managed_or_developer_token(managed, developer, &scopes).await?
+        };
+        let secret = tok.token.secret().to_owned();
+        let exp = Instant::now() + Duration::from_secs(50 * 60);
+        *self.token_cache.lock() = Some((secret.clone(), exp));
+        Ok(secret)
+    }
+
+    async fn managed_or_developer_token(
+        &self,
+        managed: &Option<Arc<azure_identity::ManagedIdentityCredential>>,
+        developer: &Arc<azure_identity::DeveloperToolsCredential>,
+        scopes: &[&str],
+    ) -> Result<azure_core::credentials::AccessToken> {
+        use azure_core::credentials::TokenCredential;
+        if let Some(managed) = managed
+            && let Ok(token) = managed.get_token(scopes, None).await
+        {
+            return Ok(token);
+        }
+        developer
+            .get_token(scopes, None)
+            .await
+            .map_err(|e| StoreError::other(anyhow::anyhow!("azure Entra token: {e}")))
+    }
+
+    fn range_header(range: &std::ops::Range<u64>) -> String {
+        format!("bytes={}-{}", range.start, range.end.saturating_sub(1))
+    }
+
+    fn quote_etag(v: &str) -> String {
+        if v == "*" || (v.starts_with('"') && v.ends_with('"')) {
+            v.to_owned()
+        } else {
+            format!("\"{v}\"")
+        }
+    }
+
+    fn apply_put_conditions(b: reqwest::RequestBuilder, mode: &PutMode) -> reqwest::RequestBuilder {
+        match mode {
+            PutMode::Overwrite => b,
+            PutMode::Create => b.header("if-none-match", "*"),
+            PutMode::Update(v) => b.header("if-match", Self::quote_etag(v.as_str())),
+        }
+    }
+
+    fn get_result_from_response(key: &str, resp: reqwest::Response) -> Result<GetResult> {
+        let status = resp.status().as_u16();
+        let etag = header_str(resp.headers(), "etag").map(|s| strip_etag(&s));
+        let content_length =
+            header_str(resp.headers(), "content-length").and_then(|s| s.parse::<u64>().ok());
+        let total = header_str(resp.headers(), "content-range").and_then(|v| {
+            v.rsplit_once('/')
+                .and_then(|(_, t)| t.trim().parse::<u64>().ok())
+        });
+        match status {
+            200 | 206 => {
+                let meta = ObjectMeta {
+                    key: key.into(),
+                    size: total.or(content_length).unwrap_or(0),
+                    version: Version::new(etag.as_deref().unwrap_or("")),
+                };
+                let body = resp
+                    .bytes_stream()
+                    .map(|r| {
+                        r.map_err(|e| StoreError::retryable(anyhow::anyhow!("azure body: {e}")))
+                    })
+                    .boxed();
+                Ok(GetResult::Object { meta, body })
+            }
+            304 => Ok(GetResult::NotModified {
+                version: Version::new(etag.as_deref().unwrap_or("")),
+            }),
+            404 => Err(StoreError::NotFound { key: key.into() }),
+            412 | 409 => Err(StoreError::PreconditionFailed {
+                key: key.into(),
+                current: etag.map(Version::new),
+            }),
+            s if s >= 500 || s == 429 => Err(StoreError::Retryable(anyhow::anyhow!(
+                "azure get status {s}"
+            ))),
+            s => Err(StoreError::Other(anyhow::anyhow!("azure get status {s}"))),
+        }
+    }
+
+    fn classify_write(key: &str, status: u16, etag: Option<String>, body: &str) -> StoreError {
+        match status {
+            404 => StoreError::NotFound { key: key.into() },
+            412 | 409 => StoreError::PreconditionFailed {
+                key: key.into(),
+                current: etag.map(Version::new),
+            },
+            s if s >= 500 || s == 429 => {
+                StoreError::Retryable(anyhow::anyhow!("azure status {s}: {body}"))
+            }
+            s => StoreError::Other(anyhow::anyhow!("azure status {s}: {body}")),
+        }
+    }
+
+    async fn put_blob(&self, key: &str, body: Bytes, opts: &PutOptions) -> Result<ObjectMeta> {
+        let len = body.len() as u64;
+        let url = self.object_url(key);
+        let mut b = self
+            .http
+            .put(&url)
+            .header("x-ms-blob-type", "BlockBlob")
+            .header("content-length", len.to_string())
+            .body(body);
+        b = Self::apply_put_conditions(b, &opts.mode);
+        if let Some(ct) = opts.content_type {
+            b = b.header("x-ms-blob-content-type", ct);
+        }
+        if opts.immutable {
+            b = b.header("x-ms-blob-cache-control", IMMUTABLE_CACHE_CONTROL);
+        }
+        let resp = self.execute(b, false).await?;
+        let status = resp.status().as_u16();
+        let etag = header_str(resp.headers(), "etag").map(|s| strip_etag(&s));
+        if (200..300).contains(&status) {
+            return Ok(ObjectMeta {
+                key: key.into(),
+                size: len,
+                version: Version::new(etag.as_deref().unwrap_or("")),
+            });
+        }
+        let body = resp.text().await.unwrap_or_default();
+        let mut err = Self::classify_write(key, status, etag, &body);
+        if let StoreError::PreconditionFailed { current: c, .. } = &mut err
+            && c.is_none()
+        {
+            *c = self.head(key).await.ok().flatten().map(|m| m.version);
+        }
+        Err(err)
+    }
+
+    fn block_id(n: u32) -> String {
+        base64::engine::general_purpose::STANDARD.encode(format!("{n:016}"))
+    }
+
+    async fn put_block(&self, key: &str, n: u32, data: Bytes, bulk: bool) -> Result<()> {
+        let id = Self::block_id(n);
+        let url = format!(
+            "{}?comp=block&blockid={}",
+            self.object_url(key),
+            query_encode(&id)
+        );
+        let len = data.len();
+        let b = self
+            .client(bulk)
+            .put(&url)
+            .header("content-length", len.to_string())
+            .header("x-ms-blob-type", "BlockBlob")
+            .body(data);
+        let resp = self.execute(b, bulk).await?;
+        let status = resp.status().as_u16();
+        if (200..300).contains(&status) {
+            return Ok(());
+        }
+        let body = resp.text().await.unwrap_or_default();
+        Err(Self::classify_write(key, status, None, &body))
+    }
+
+    async fn put_block_from_url(
+        &self,
+        dest: &str,
+        n: u32,
+        source_url: &str,
+        range: std::ops::Range<u64>,
+    ) -> Result<()> {
+        let id = Self::block_id(n);
+        let url = format!(
+            "{}?comp=block&blockid={}",
+            self.object_url(dest),
+            query_encode(&id)
+        );
+        let src_range = format!("bytes={}-{}", range.start, range.end.saturating_sub(1));
+        let b = self
+            .bulk
+            .put(&url)
+            .header("content-length", "0")
+            .header("x-ms-copy-source", source_url)
+            .header("x-ms-source-range", src_range)
+            .body(Bytes::new());
+        let resp = self.execute(b, true).await?;
+        let status = resp.status().as_u16();
+        if (200..300).contains(&status) {
+            return Ok(());
+        }
+        let body = resp.text().await.unwrap_or_default();
+        Err(Self::classify_write(dest, status, None, &body))
+    }
+
+    fn from_url_unsupported(err: &StoreError) -> bool {
+        let s = err.to_string().to_ascii_lowercase();
+        s.contains("not yet")
+            || s.contains("not implemented")
+            || s.contains("not supported")
+            || s.contains("featurenotyet")
+            || s.contains("apinotimplemented")
+            || s.contains("apiversionnotsupported")
+            || s.contains("put block from url")
+            || s.contains("status 501")
+    }
+
+    async fn commit_block_list(
+        &self,
+        key: &str,
+        n_blocks: u32,
+        opts: &PutOptions,
+        size: u64,
+    ) -> Result<ObjectMeta> {
+        let mut xml = String::from("<?xml version=\"1.0\" encoding=\"utf-8\"?><BlockList>");
+        for i in 0..n_blocks {
+            xml.push_str("<Latest>");
+            xml.push_str(&Self::block_id(i));
+            xml.push_str("</Latest>");
+        }
+        xml.push_str("</BlockList>");
+        let url = format!("{}?comp=blocklist", self.object_url(key));
+        let mut b = self
+            .http
+            .put(&url)
+            .header("content-type", "application/xml")
+            .header("content-length", xml.len().to_string())
+            .body(xml);
+        b = Self::apply_put_conditions(b, &opts.mode);
+        if let Some(ct) = opts.content_type {
+            b = b.header("x-ms-blob-content-type", ct);
+        }
+        if opts.immutable {
+            b = b.header("x-ms-blob-cache-control", IMMUTABLE_CACHE_CONTROL);
+        }
+        let resp = self.execute(b, false).await?;
+        let status = resp.status().as_u16();
+        let etag = header_str(resp.headers(), "etag").map(|s| strip_etag(&s));
+        if (200..300).contains(&status) {
+            return Ok(ObjectMeta {
+                key: key.into(),
+                size,
+                version: Version::new(etag.as_deref().unwrap_or("")),
+            });
+        }
+        let body = resp.text().await.unwrap_or_default();
+        let mut err = Self::classify_write(key, status, etag, &body);
+        if let StoreError::PreconditionFailed { current: c, .. } = &mut err
+            && c.is_none()
+        {
+            *c = self.head(key).await.ok().flatten().map(|m| m.version);
+        }
+        Err(err)
+    }
+
+    async fn put_blocks_bytes(
+        &self,
+        key: &str,
+        data: Bytes,
+        opts: &PutOptions,
+    ) -> Result<ObjectMeta> {
+        let size = data.len() as u64;
+        let part = self.multipart_part_size as usize;
+        let mut n = 0u32;
+        let mut offset = 0usize;
+        while offset < data.len() {
+            let end = (offset + part).min(data.len());
+            self.put_block(key, n, data.slice(offset..end), true)
+                .await?;
+            n += 1;
+            offset = end;
+        }
+        if n == 0 {
+            self.put_block(key, 0, Bytes::new(), false).await?;
+            n = 1;
+        }
+        self.commit_block_list(key, n, opts, size).await
+    }
+
+    async fn put_stream(
+        &self,
+        key: &str,
+        mut stream: crate::ByteStream,
+        len: u64,
+        opts: &PutOptions,
+    ) -> Result<ObjectMeta> {
+        let part = self.multipart_part_size as usize;
+        let mut buf = bytes::BytesMut::new();
+        let mut n = 0u32;
+        while let Some(chunk) = stream.next().await {
+            buf.extend_from_slice(&chunk?);
+            while buf.len() >= part {
+                let block = buf.split_to(part).freeze();
+                self.put_block(key, n, block, true).await?;
+                n += 1;
+            }
+        }
+        if !buf.is_empty() || n == 0 {
+            self.put_block(key, n, buf.freeze(), n > 0).await?;
+            n += 1;
+        }
+        self.commit_block_list(key, n, opts, len).await
+    }
+
+    async fn list_page(
+        &self,
+        prefix: &str,
+        marker: Option<&str>,
+        delimiter: Option<&str>,
+        max_results: u32,
+    ) -> Result<ListPage> {
+        let mut url = format!("{}?restype=container&comp=list", self.container_url());
+        if !prefix.is_empty() {
+            url.push_str("&prefix=");
+            url.push_str(&query_encode(prefix));
+        }
+        if let Some(m) = marker.filter(|s| !s.is_empty()) {
+            url.push_str("&marker=");
+            url.push_str(&query_encode(m));
+        }
+        if let Some(d) = delimiter {
+            url.push_str("&delimiter=");
+            url.push_str(&query_encode(d));
+        }
+        url.push_str("&maxresults=");
+        url.push_str(&max_results.to_string());
+        url.push_str("&include=");
+        let resp = self.execute(self.http.get(&url), false).await?;
+        let status = resp.status().as_u16();
+        if !(200..300).contains(&status) {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(Self::classify_write(prefix, status, None, &body));
+        }
+        let body = resp
+            .text()
+            .await
+            .map_err(|e| StoreError::other(anyhow::anyhow!("azure list body: {e}")))?;
+        Ok(parse_list_xml(&body))
+    }
+
+    /// Service SAS (account key) or user-delegation SAS (Entra).
+    async fn mint_sas(&self, key: &str, ttl: Duration) -> Result<String> {
+        let start = Utc::now() - chrono::Duration::minutes(5);
+        let expiry =
+            Utc::now() + chrono::Duration::from_std(ttl).unwrap_or(chrono::Duration::hours(1));
+        let st = start.to_rfc3339_opts(SecondsFormat::Secs, true);
+        let se = expiry.to_rfc3339_opts(SecondsFormat::Secs, true);
+        let resource = format!("/blob/{}/{}/{}", self.account, self.container, key);
+        match &self.auth {
+            AzureAuth::SharedKey { key: account_key } => {
+                // sp + st + se + canonicalizedResource + ident + ip + proto + sv + sr + snapshot
+                // + enc + rscc + rscd + rsce + rscl + rsct  (2020-12-06+)
+                let string_to_sign =
+                    format!("r\n{st}\n{se}\n{resource}\n\n\n\n{API_VERSION}\nb\n\n\n\n\n\n\n");
+                let sig = hmac_b64(account_key, &string_to_sign);
+                Ok(format!(
+                    "{}?{}sp=r&st={}&se={}&sv={}&sr=b&sig={}",
+                    self.object_url(key),
+                    if self.object_url(key).contains('?') {
+                        "&"
+                    } else {
+                        ""
+                    },
+                    query_encode(&st),
+                    query_encode(&se),
+                    API_VERSION,
+                    query_encode(&sig)
+                )
+                .replace("?&", "?"))
+            }
+            AzureAuth::Bearer { .. } => {
+                let udef = self.user_delegation_key(&st, &se).await?;
+                let string_to_sign = format!(
+                    "r\n{st}\n{se}\n{resource}\n{}\n{}\n{}\n{}\n{}\n{}\n\n\n\n\n{API_VERSION}\nb\n\n\n\n\n\n\n",
+                    udef.oid, udef.tid, udef.start, udef.expiry, udef.service, udef.version
+                );
+                let sig = hmac_b64(&udef.key, &string_to_sign);
+                Ok(format!(
+                    "{}?sp=r&st={}&se={}&sv={}&sr=b&skoid={}&sktid={}&skt={}&ske={}&sks={}&skv={}&sig={}",
+                    self.object_url(key),
+                    query_encode(&st),
+                    query_encode(&se),
+                    API_VERSION,
+                    query_encode(&udef.oid),
+                    query_encode(&udef.tid),
+                    query_encode(&udef.start),
+                    query_encode(&udef.expiry),
+                    query_encode(&udef.service),
+                    query_encode(&udef.version),
+                    query_encode(&sig),
+                ))
+            }
+        }
+    }
+
+    async fn user_delegation_key(&self, start: &str, expiry: &str) -> Result<UserDelegation> {
+        let url = format!(
+            "{}?restype=service&comp=userdelegationkey",
+            self.service_url
+        );
+        let body = format!(
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?><KeyInfo><Start>{start}</Start><Expiry>{expiry}</Expiry></KeyInfo>"
+        );
+        let resp = self
+            .execute(
+                self.http
+                    .post(&url)
+                    .header("content-type", "application/xml")
+                    .header("content-length", body.len().to_string())
+                    .body(body),
+                false,
+            )
+            .await?;
+        let status = resp.status().as_u16();
+        let text = resp.text().await.unwrap_or_default();
+        if !(200..300).contains(&status) {
+            return Err(StoreError::other(anyhow::anyhow!(
+                "azure user delegation key {status}: {text}"
+            )));
+        }
+        let value = xml_text(&text, "Value").ok_or_else(|| {
+            StoreError::other(anyhow::anyhow!("azure user delegation key: no Value"))
+        })?;
+        let key = base64::engine::general_purpose::STANDARD
+            .decode(value.trim())
+            .map_err(|e| StoreError::other(anyhow::anyhow!("azure udef key: {e}")))?;
+        Ok(UserDelegation {
+            oid: xml_text(&text, "SignedOid").unwrap_or_default().to_owned(),
+            tid: xml_text(&text, "SignedTid").unwrap_or_default().to_owned(),
+            start: xml_text(&text, "SignedStart").unwrap_or(start).to_owned(),
+            expiry: xml_text(&text, "SignedExpiry").unwrap_or(expiry).to_owned(),
+            service: xml_text(&text, "SignedService").unwrap_or("b").to_owned(),
+            version: xml_text(&text, "SignedVersion")
+                .unwrap_or(API_VERSION)
+                .to_owned(),
+            key,
+        })
+    }
+}
+
+struct UserDelegation {
+    oid: String,
+    tid: String,
+    start: String,
+    expiry: String,
+    service: String,
+    version: String,
+    key: Vec<u8>,
+}
+
+struct ParsedAzure {
+    account: String,
+    service_url: String,
+    path_style: bool,
+    auth: AzureAuth,
+}
+
+fn resolve_azure(cfg: &walgit_config::StoreConfig) -> anyhow::Result<ParsedAzure> {
+    let a = &cfg.azure;
+    let conn = if a.connection_string_env.is_empty() {
+        None
+    } else {
+        std::env::var(&a.connection_string_env).ok()
+    };
+    let (mut account, mut endpoint, mut key_b64) = if let Some(cs) = conn.as_deref() {
+        parse_connection_string(cs)?
+    } else {
+        (a.account.clone(), a.endpoint.clone(), None)
+    };
+    if account.is_empty() {
+        account = a.account.clone();
+    }
+    if endpoint.is_empty() {
+        endpoint = a.endpoint.clone();
+    }
+    if key_b64.is_none() {
+        if let Ok(k) = std::env::var(&a.account_key_env) {
+            if !k.is_empty() {
+                key_b64 = Some(k);
+            }
+        }
+    }
+    if account.is_empty() {
+        anyhow::bail!(
+            "azure: store.azure.account is empty (or set {} with AccountName)",
+            a.connection_string_env
+        );
+    }
+    let auth = if let Some(k) = key_b64 {
+        let key = base64::engine::general_purpose::STANDARD
+            .decode(k.trim())
+            .map_err(|e| anyhow::anyhow!("azure: account key is not valid base64: {e}"))?;
+        AzureAuth::SharedKey { key }
+    } else if a.use_aad {
+        let workload = azure_identity::WorkloadIdentityCredential::new(None).ok();
+        let managed = azure_identity::ManagedIdentityCredential::new(None).ok();
+        let developer = azure_identity::DeveloperToolsCredential::new(None)
+            .map_err(|e| anyhow::anyhow!("azure Entra credential: {e}"))?;
+        AzureAuth::Bearer {
+            workload,
+            managed,
+            developer,
+        }
+    } else {
+        anyhow::bail!(
+            "azure: no credentials (set env {} for the account key, {} for a connection string, or store.azure.use_aad = true)",
+            a.account_key_env,
+            a.connection_string_env
+        );
+    };
+    let (service_url, path_style) = service_url_for(&account, &endpoint);
+    Ok(ParsedAzure {
+        account,
+        service_url,
+        path_style,
+        auth,
+    })
+}
+
+fn parse_connection_string(cs: &str) -> anyhow::Result<(String, String, Option<String>)> {
+    if cs.eq_ignore_ascii_case("UseDevelopmentStorage=true")
+        || cs
+            .to_ascii_lowercase()
+            .contains("usedevelopmentstorage=true")
+    {
+        return Ok((
+            WELL_KNOWN_ACCOUNT.into(),
+            "http://127.0.0.1:10000".into(),
+            Some(WELL_KNOWN_KEY.into()),
+        ));
+    }
+    let mut account = String::new();
+    let mut key = None;
+    let mut blob_endpoint = String::new();
+    let mut protocol = "https".to_owned();
+    for part in cs.split(';') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        let Some((k, v)) = part.split_once('=') else {
+            continue;
+        };
+        match k.trim().to_ascii_lowercase().as_str() {
+            "accountname" => account = v.trim().to_owned(),
+            "accountkey" => key = Some(v.trim().to_owned()),
+            "blobendpoint" => blob_endpoint = v.trim().to_owned(),
+            "defaultendpointsprotocol" => protocol = v.trim().to_owned(),
+            _ => {}
+        }
+    }
+    let endpoint = if !blob_endpoint.is_empty() {
+        // Azurite BlobEndpoint includes /{account}; strip it so we re-add as path-style.
+        match reqwest::Url::parse(&blob_endpoint) {
+            Ok(u) => {
+                let origin = format!(
+                    "{}://{}{}",
+                    u.scheme(),
+                    u.host_str().unwrap_or(""),
+                    u.port().map(|p| format!(":{p}")).unwrap_or_default()
+                );
+                origin
+            }
+            Err(_) => blob_endpoint,
+        }
+    } else if !account.is_empty() {
+        format!("{protocol}://{account}.blob.core.windows.net")
+    } else {
+        String::new()
+    };
+    Ok((account, endpoint, key))
+}
+
+fn service_url_for(account: &str, endpoint: &str) -> (String, bool) {
+    if endpoint.is_empty() {
+        return (format!("https://{account}.blob.core.windows.net"), false);
+    }
+    let endpoint = endpoint.trim_end_matches('/');
+    let Ok(u) = reqwest::Url::parse(endpoint) else {
+        return (endpoint.to_owned(), true);
+    };
+    let host = u.host_str().unwrap_or("");
+    let path_style = !host.eq_ignore_ascii_case(&format!("{account}.blob.core.windows.net"))
+        && !host
+            .to_ascii_lowercase()
+            .starts_with(&format!("{}.blob.", account.to_ascii_lowercase()));
+    if path_style {
+        let origin = format!(
+            "{}://{}{}",
+            u.scheme(),
+            host,
+            u.port().map(|p| format!(":{p}")).unwrap_or_default()
+        );
+        (format!("{origin}/{account}"), true)
+    } else {
+        let origin = format!(
+            "{}://{}{}",
+            u.scheme(),
+            host,
+            u.port().map(|p| format!(":{p}")).unwrap_or_default()
+        );
+        (origin, false)
+    }
+}
+
+fn shared_key_auth(
+    account: &str,
+    key: &[u8],
+    method: &reqwest::Method,
+    url: &reqwest::Url,
+    headers: &reqwest::header::HeaderMap,
+) -> Result<String> {
+    let sts = string_to_sign(account, method, url, headers);
+    let sig = hmac_b64(key, &sts);
+    Ok(format!("SharedKey {account}:{sig}"))
+}
+
+fn string_to_sign(
+    account: &str,
+    method: &reqwest::Method,
+    url: &reqwest::Url,
+    headers: &reqwest::header::HeaderMap,
+) -> String {
+    let content_length = header_str(headers, "content-length")
+        .filter(|v| v != "0")
+        .unwrap_or_default();
+    format!(
+        "{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}{}",
+        method.as_str(),
+        header_str(headers, "content-encoding").unwrap_or_default(),
+        header_str(headers, "content-language").unwrap_or_default(),
+        content_length,
+        header_str(headers, "content-md5").unwrap_or_default(),
+        header_str(headers, "content-type").unwrap_or_default(),
+        header_str(headers, "date").unwrap_or_default(),
+        header_str(headers, "if-modified-since").unwrap_or_default(),
+        header_str(headers, "if-match").unwrap_or_default(),
+        header_str(headers, "if-none-match").unwrap_or_default(),
+        header_str(headers, "if-unmodified-since").unwrap_or_default(),
+        header_str(headers, "range").unwrap_or_default(),
+        canonicalize_headers(headers),
+        canonicalize_resource(account, url),
+    )
+}
+
+fn canonicalize_headers(headers: &reqwest::header::HeaderMap) -> String {
+    let mut ms: Vec<(String, String)> = headers
+        .iter()
+        .filter_map(|(k, v)| {
+            let name = k.as_str().to_ascii_lowercase();
+            if !name.starts_with("x-ms-") {
+                return None;
+            }
+            let val = v.to_str().ok()?.trim().to_owned();
+            Some((name, val))
+        })
+        .collect();
+    ms.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut out = String::new();
+    for (n, v) in ms {
+        out.push_str(&n);
+        out.push(':');
+        out.push_str(&v);
+        out.push('\n');
+    }
+    out
+}
+
+fn canonicalize_resource(account: &str, url: &reqwest::Url) -> String {
+    let mut can = String::new();
+    can.push('/');
+    can.push_str(account);
+    can.push_str(url.path());
+    let mut params: Vec<(String, String)> = url
+        .query_pairs()
+        .map(|(k, v)| (k.to_ascii_lowercase(), v.into_owned()))
+        .collect();
+    params.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
+    for (n, v) in params {
+        can.push('\n');
+        can.push_str(&n);
+        can.push(':');
+        can.push_str(&v);
+    }
+    can
+}
+
+fn hmac_b64(key: &[u8], data: &str) -> String {
+    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC-SHA256 accepts any key length");
+    mac.update(data.as_bytes());
+    base64::engine::general_purpose::STANDARD.encode(mac.finalize().into_bytes())
+}
+
+fn header_str(h: &reqwest::header::HeaderMap, name: &str) -> Option<String> {
+    h.get(name)?.to_str().ok().map(|s| s.to_owned())
+}
+
+fn strip_etag(v: &str) -> String {
+    v.trim()
+        .replace("&quot;", "\"")
+        .trim_matches('"')
+        .to_owned()
+}
+
+fn query_encode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char)
+            }
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
+fn xml_text<'a>(s: &'a str, tag: &str) -> Option<&'a str> {
+    let open = format!("<{tag}>");
+    let open_alt = format!("<{tag} ");
+    let close = format!("</{tag}>");
+    let start = if let Some(i) = s.find(&open) {
+        i + open.len()
+    } else if let Some(i) = s.find(&open_alt) {
+        s[i..].find('>')? + i + 1
+    } else {
+        return None;
+    };
+    let end = s[start..].find(&close)? + start;
+    Some(&s[start..end])
+}
+
+struct ListPage {
+    blobs: Vec<ObjectMeta>,
+    prefixes: Vec<String>,
+    next_marker: Option<String>,
+}
+
+fn parse_list_xml(body: &str) -> ListPage {
+    let mut blobs = Vec::new();
+    let mut prefixes = Vec::new();
+    // Walk <Blob>…</Blob> (not BlobPrefix).
+    let mut rest = body;
+    while let Some(start) = rest.find("<Blob>") {
+        let after = &rest[start + 6..];
+        let Some(end) = after.find("</Blob>") else {
+            break;
+        };
+        let blob = &after[..end];
+        rest = &after[end + 7..];
+        // Skip BlobPrefix accidentally? <Blob> doesn't match BlobPrefix.
+        let Some(name) = xml_text(blob, "Name") else {
+            continue;
+        };
+        let name = xml_unescape(name);
+        let size = xml_text(blob, "Content-Length")
+            .and_then(|s| s.trim().parse::<u64>().ok())
+            .unwrap_or(0);
+        let etag = xml_text(blob, "Etag")
+            .or_else(|| xml_text(blob, "ETag"))
+            .map(strip_etag)
+            .unwrap_or_default();
+        blobs.push(ObjectMeta {
+            key: name,
+            size,
+            version: Version::new(etag),
+        });
+    }
+    rest = body;
+    while let Some(start) = rest.find("<BlobPrefix>") {
+        let after = &rest[start + 12..];
+        let Some(end) = after.find("</BlobPrefix>") else {
+            break;
+        };
+        let p = &after[..end];
+        rest = &after[end + 13..];
+        if let Some(name) = xml_text(p, "Name") {
+            prefixes.push(xml_unescape(name));
+        }
+    }
+    let next_marker = xml_text(body, "NextMarker")
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty());
+    ListPage {
+        blobs,
+        prefixes,
+        next_marker,
+    }
+}
+
+fn xml_unescape(s: &str) -> String {
+    s.replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&apos;", "'")
+}
+
+#[async_trait::async_trait]
+impl ObjectStore for AzureStore {
+    fn backend(&self) -> &'static str {
+        "azure"
+    }
+
+    async fn get(&self, key: &str, opts: GetOptions) -> Result<GetResult> {
+        let url = self.object_url(key);
+        let mut b = self.bulk.get(&url);
+        if let Some(v) = &opts.if_none_match {
+            b = b.header("if-none-match", Self::quote_etag(v.as_str()));
+        }
+        if let Some(v) = &opts.if_match {
+            b = b.header("if-match", Self::quote_etag(v.as_str()));
+        }
+        if let Some(r) = &opts.range {
+            b = b.header("range", Self::range_header(r));
+        }
+        let resp = self.execute(b, true).await?;
+        Self::get_result_from_response(key, resp)
+    }
+
+    async fn head(&self, key: &str) -> Result<Option<ObjectMeta>> {
+        let url = self.object_url(key);
+        let resp = self.execute(self.http.head(&url), false).await?;
+        let status = resp.status().as_u16();
+        match status {
+            200 => {
+                let etag = header_str(resp.headers(), "etag").map(|s| strip_etag(&s));
+                let size = header_str(resp.headers(), "content-length")
+                    .and_then(|s| s.parse::<u64>().ok())
+                    .unwrap_or(0);
+                Ok(Some(ObjectMeta {
+                    key: key.into(),
+                    size,
+                    version: Version::new(etag.as_deref().unwrap_or("")),
+                }))
+            }
+            404 => Ok(None),
+            s => {
+                let body = resp.text().await.unwrap_or_default();
+                Err(Self::classify_write(key, s, None, &body))
+            }
+        }
+    }
+
+    async fn put(&self, key: &str, body: PutBody, opts: PutOptions) -> Result<ObjectMeta> {
+        match body {
+            PutBody::Bytes(b) => {
+                if b.len() as u64 > self.multipart_threshold {
+                    self.put_blocks_bytes(key, b, &opts).await
+                } else {
+                    self.put_blob(key, b, &opts).await
+                }
+            }
+            PutBody::Stream { len, stream } => {
+                if len > self.multipart_threshold {
+                    self.put_stream(key, stream, len, &opts).await
+                } else {
+                    let collected = util::collect(stream, len as usize).await?;
+                    self.put_blob(key, collected, &opts).await
+                }
+            }
+            PutBody::File(path) => {
+                let meta = tokio::fs::metadata(&path).await.map_err(|e| {
+                    StoreError::other(anyhow::anyhow!("stat {}: {e}", path.display()))
+                })?;
+                let len = meta.len();
+                if len > self.multipart_threshold {
+                    let stream = util::file_stream(path, None, 1024 * 1024);
+                    self.put_stream(key, stream, len, &opts).await
+                } else {
+                    let data = tokio::fs::read(&path).await.map_err(|e| {
+                        StoreError::other(anyhow::anyhow!("read {}: {e}", path.display()))
+                    })?;
+                    self.put_blob(key, Bytes::from(data), &opts).await
+                }
+            }
+        }
+    }
+
+    async fn delete(&self, key: &str, if_version: Option<Version>) -> Result<()> {
+        if let Some(want) = &if_version {
+            // Azure/Azurite may answer 412 (not 404) for If-Match on a missing
+            // blob; HEAD first so absent + conditional is NotFound, as the
+            // contract requires.
+            match self.head(key).await? {
+                None => return Err(StoreError::NotFound { key: key.into() }),
+                Some(meta) if &meta.version != want => {
+                    return Err(StoreError::PreconditionFailed {
+                        key: key.into(),
+                        current: Some(meta.version),
+                    });
+                }
+                _ => {}
+            }
+        }
+        let url = self.object_url(key);
+        let mut b = self.http.delete(&url);
+        if let Some(v) = &if_version {
+            b = b.header("if-match", Self::quote_etag(v.as_str()));
+        }
+        let resp = self.execute(b, false).await?;
+        let status = resp.status().as_u16();
+        match status {
+            200 | 202 => Ok(()),
+            404 if if_version.is_none() => Ok(()),
+            404 => Err(StoreError::NotFound { key: key.into() }),
+            412 | 409 => {
+                let etag = header_str(resp.headers(), "etag").map(|s| strip_etag(&s));
+                Err(StoreError::PreconditionFailed {
+                    key: key.into(),
+                    current: etag.map(Version::new),
+                })
+            }
+            s => {
+                let body = resp.text().await.unwrap_or_default();
+                Err(Self::classify_write(key, s, None, &body))
+            }
+        }
+    }
+
+    fn list(
+        &self,
+        prefix: &str,
+        start_after: Option<&str>,
+    ) -> BoxStream<'static, Result<ObjectMeta>> {
+        let this_account = self.account.clone();
+        let this_service = self.service_url.clone();
+        let this_container = self.container.clone();
+        let http = self.http.clone();
+        let bulk = self.bulk.clone();
+        let auth = match &self.auth {
+            AzureAuth::SharedKey { key } => AzureAuth::SharedKey { key: key.clone() },
+            AzureAuth::Bearer {
+                workload,
+                managed,
+                developer,
+            } => AzureAuth::Bearer {
+                workload: workload.clone(),
+                managed: managed.clone(),
+                developer: developer.clone(),
+            },
+        };
+        let prefix = prefix.to_owned();
+        let start_after = start_after.map(|s| s.to_owned());
+        let multipart_threshold = self.multipart_threshold;
+        let multipart_part_size = self.multipart_part_size;
+        let path_style = self.path_style;
+        // Reconstruct a store handle for paging (clients are cheap Arc internals).
+        let store = AzureStore {
+            http,
+            bulk,
+            account: this_account,
+            service_url: this_service,
+            container: this_container,
+            auth,
+            path_style,
+            multipart_threshold,
+            multipart_part_size,
+            token_cache: Mutex::new(None),
+        };
+        Box::pin(futures::stream::unfold(
+            ListState {
+                store,
+                prefix,
+                start_after,
+                marker: None,
+                started: false,
+                buffer: Vec::new().into_iter(),
+            },
+            |mut state| async move {
+                loop {
+                    if let Some(item) = state.buffer.next() {
+                        return Some((item, state));
+                    }
+                    if state.started && state.marker.is_none() {
+                        return None;
+                    }
+                    state.started = true;
+                    match state
+                        .store
+                        .list_page(&state.prefix, state.marker.as_deref(), None, 1000)
+                        .await
+                    {
+                        Ok(page) => {
+                            state.marker = page.next_marker;
+                            let skip = state.start_after.as_deref();
+                            let items: Vec<Result<ObjectMeta>> = page
+                                .blobs
+                                .into_iter()
+                                .filter(|m| skip.is_none_or(|s| m.key.as_str() > s))
+                                .map(Ok)
+                                .collect();
+                            if items.is_empty() && state.marker.is_some() {
+                                continue;
+                            }
+                            state.buffer = items.into_iter();
+                            let item = state.buffer.next();
+                            return item.map(|i| (i, state));
+                        }
+                        Err(e) => return Some((Err(e), state)),
+                    }
+                }
+            },
+        ))
+    }
+
+    async fn list_prefixes(&self, prefix: &str) -> Result<Vec<String>> {
+        let mut out = Vec::new();
+        let mut marker = None;
+        loop {
+            let page = self
+                .list_page(prefix, marker.as_deref(), Some("/"), 1000)
+                .await?;
+            out.extend(page.prefixes);
+            marker = page.next_marker;
+            if marker.is_none() {
+                break;
+            }
+        }
+        out.sort();
+        out.dedup();
+        Ok(out)
+    }
+
+    async fn signed_get_url(&self, key: &str, ttl: Duration) -> Result<Option<String>> {
+        Ok(Some(self.mint_sas(key, ttl).await?))
+    }
+
+    async fn accel_target(&self, key: &str) -> Option<crate::AccelTarget> {
+        let url = self
+            .signed_get_url(key, Duration::from_secs(3600))
+            .await
+            .ok()
+            .flatten()?;
+        Some(crate::AccelTarget {
+            url,
+            authorization: None,
+        })
+    }
+
+    fn supports_compose(&self) -> bool {
+        true
+    }
+
+    fn compose_is_native(&self) -> bool {
+        false
+    }
+
+    async fn compose(
+        &self,
+        dest: &str,
+        sources: &[String],
+        opts: PutOptions,
+    ) -> Result<ObjectMeta> {
+        if sources.is_empty() {
+            return Err(StoreError::InvalidArgument(
+                "compose needs at least one source".into(),
+            ));
+        }
+        if let PutMode::Create = opts.mode
+            && self.head(dest).await?.is_some()
+        {
+            return Err(StoreError::PreconditionFailed {
+                key: dest.to_owned(),
+                current: None,
+            });
+        }
+        let mut sizes = Vec::with_capacity(sources.len());
+        for src in sources {
+            let m = self
+                .head(src)
+                .await?
+                .ok_or_else(|| StoreError::NotFound { key: src.clone() })?;
+            sizes.push(m.size);
+        }
+        let total: u64 = sizes.iter().sum();
+        let mut n = 0u32;
+        for (src, size) in sources.iter().zip(sizes.iter().copied()) {
+            if size == 0 {
+                self.put_block(dest, n, Bytes::new(), false).await?;
+                n += 1;
+                continue;
+            }
+            let sas = self.mint_sas(src, Duration::from_secs(3600)).await?;
+            let mut off = 0u64;
+            while off < size {
+                let end = (off + COPY_CHUNK).min(size);
+                match self.put_block_from_url(dest, n, &sas, off..end).await {
+                    Ok(()) => {}
+                    Err(e) if Self::from_url_unsupported(&e) => {
+                        tracing::warn!(
+                            dest,
+                            src,
+                            error = %e,
+                            "azure Put Block From URL unavailable on this endpoint; fetching source through the process"
+                        );
+                        eprintln!(
+                            "azure compose: Put Block From URL unavailable ({e}); fetching {src} through the process"
+                        );
+                        let r = self
+                            .get(
+                                src,
+                                GetOptions {
+                                    range: Some(off..end),
+                                    ..GetOptions::default()
+                                },
+                            )
+                            .await?;
+                        let bytes = match r {
+                            GetResult::Object { body, .. } => {
+                                util::collect(body, (end - off) as usize).await?
+                            }
+                            GetResult::NotModified { .. } => {
+                                return Err(StoreError::NotFound { key: src.clone() });
+                            }
+                        };
+                        self.put_block(dest, n, bytes, true).await?;
+                    }
+                    Err(e) => return Err(e),
+                }
+                n += 1;
+                off = end;
+            }
+        }
+        self.commit_block_list(dest, n, &opts, total).await
+    }
+}
+
+struct ListState {
+    store: AzureStore,
+    prefix: String,
+    start_after: Option<String>,
+    marker: Option<String>,
+    started: bool,
+    buffer: std::vec::IntoIter<Result<ObjectMeta>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn service_url_production_is_host_style() {
+        let (u, path) = service_url_for("myacct", "");
+        assert_eq!(u, "https://myacct.blob.core.windows.net");
+        assert!(!path);
+        let (u, path) = service_url_for("myacct", "https://myacct.blob.core.windows.net");
+        assert_eq!(u, "https://myacct.blob.core.windows.net");
+        assert!(!path);
+    }
+
+    #[test]
+    fn service_url_azurite_is_path_style() {
+        let (u, path) = service_url_for("devstoreaccount1", "http://127.0.0.1:10000");
+        assert_eq!(u, "http://127.0.0.1:10000/devstoreaccount1");
+        assert!(path);
+    }
+
+    #[test]
+    fn connection_string_azurite_shortcut() {
+        let (acct, ep, key) = parse_connection_string("UseDevelopmentStorage=true").unwrap();
+        assert_eq!(acct, WELL_KNOWN_ACCOUNT);
+        assert!(ep.contains("127.0.0.1"));
+        assert!(key.is_some());
+    }
+
+    #[test]
+    fn connection_string_parses_fields() {
+        let (acct, ep, key) = parse_connection_string(
+            "DefaultEndpointsProtocol=https;AccountName=foo;AccountKey=YWJjZA==;EndpointSuffix=core.windows.net",
+        )
+        .unwrap();
+        assert_eq!(acct, "foo");
+        assert_eq!(ep, "https://foo.blob.core.windows.net");
+        assert_eq!(key.as_deref(), Some("YWJjZA=="));
+    }
+
+    #[test]
+    fn etag_roundtrip_quotes() {
+        assert_eq!(strip_etag("\"0xABC\""), "0xABC");
+        assert_eq!(strip_etag("&quot;0xABC&quot;"), "0xABC");
+        assert_eq!(AzureStore::quote_etag("0xABC"), "\"0xABC\"");
+        assert_eq!(AzureStore::quote_etag("*"), "*");
+    }
+
+    #[test]
+    fn list_xml_blobs_and_prefixes() {
+        let xml = r#"
+<EnumerationResults>
+  <Blobs>
+    <Blob><Name>a/b</Name><Properties><Content-Length>3</Content-Length><Etag>"0x1"</Etag></Properties></Blob>
+    <BlobPrefix><Name>a/c/</Name></BlobPrefix>
+  </Blobs>
+  <NextMarker>more</NextMarker>
+</EnumerationResults>"#;
+        let p = parse_list_xml(xml);
+        assert_eq!(p.blobs.len(), 1);
+        assert_eq!(p.blobs[0].key, "a/b");
+        assert_eq!(p.blobs[0].size, 3);
+        assert_eq!(p.blobs[0].version.as_str(), "0x1");
+        assert_eq!(p.prefixes, vec!["a/c/".to_string()]);
+        assert_eq!(p.next_marker.as_deref(), Some("more"));
+    }
+
+    #[test]
+    fn canonicalized_resource_includes_account_and_sorted_query() {
+        let url = reqwest::Url::parse(
+            "http://127.0.0.1:10000/devstoreaccount1/c/k?comp=list&restype=container",
+        )
+        .unwrap();
+        let r = canonicalize_resource("devstoreaccount1", &url);
+        assert!(r.starts_with("/devstoreaccount1/devstoreaccount1/c/k\n"));
+        assert!(r.contains("\ncomp:list"));
+        assert!(r.contains("\nrestype:container"));
+    }
+
+    #[tokio::test]
+    async fn missing_creds_fail_closed() {
+        let mut cfg = walgit_config::Config::default();
+        cfg.store.backend = walgit_config::StoreBackend::Azure;
+        cfg.store.bucket = "walgit-test".into();
+        cfg.store.azure.account = "devstoreaccount1".into();
+        cfg.store.azure.account_key_env = "WALGIT_TEST_AZURE_KEY_MUST_NOT_EXIST_9f3a".into();
+        cfg.store.azure.connection_string_env = "WALGIT_TEST_AZURE_CONN_MUST_NOT_EXIST_9f3a".into();
+        cfg.store.azure.use_aad = false;
+        let err = match crate::open_store(&cfg).await {
+            Ok(_) => panic!("missing creds must fail"),
+            Err(e) => e.to_string(),
+        };
+        assert!(err.to_ascii_lowercase().contains("azure"), "{err}");
+        assert!(
+            err.contains("WALGIT_TEST_AZURE_KEY_MUST_NOT_EXIST_9f3a")
+                || err.contains("account key")
+                || err.contains("connection string"),
+            "{err}"
+        );
+    }
+}

--- a/crates/walgit-store/src/lib.rs
+++ b/crates/walgit-store/src/lib.rs
@@ -7,7 +7,7 @@
 //! * conditional writes (`Create` = if-absent, `Update(v)` = CAS on version),
 //! * conditional deletes, range reads, streaming bodies, prefix listing.
 //!
-//! [`Version`] is opaque to callers: GCS generation, S3/rustfs ETag, or a
+//! [`Version`] is opaque to callers: GCS generation, S3/Azure ETag, or a
 //! counter in [`memory::MemoryStore`]. Callers must never parse it.
 
 use std::{fmt, ops::Range, pin::Pin, sync::Arc};
@@ -18,6 +18,8 @@ use tracing::Instrument;
 
 pub mod coord;
 pub use coord::CoordError;
+#[cfg(feature = "azure")]
+pub mod azure;
 pub mod fault;
 #[cfg(feature = "gcs")]
 pub mod gcs;
@@ -200,7 +202,7 @@ pub type Result<T, E = StoreError> = std::result::Result<T, E>;
 
 #[async_trait::async_trait]
 pub trait ObjectStore: Send + Sync + 'static {
-    /// Human-readable backend id for logs/metrics ("gcs", "s3", "memory").
+    /// Human-readable backend id for logs/metrics ("gcs", "s3", "azure", "memory").
     fn backend(&self) -> &'static str;
     /// Whether this store is a prefixing wrapper. Used to avoid duplicate
     /// operation spans when prefixes are nested.
@@ -656,6 +658,16 @@ pub async fn open_store(cfg: &walgit_config::Config) -> anyhow::Result<DynStore>
             #[cfg(not(feature = "gcs"))]
             {
                 anyhow::bail!("gcs backend requires the `gcs` feature")
+            }
+        }
+        walgit_config::StoreBackend::Azure => {
+            #[cfg(feature = "azure")]
+            {
+                Arc::new(azure::AzureStore::new(&cfg.store).await?)
+            }
+            #[cfg(not(feature = "azure"))]
+            {
+                anyhow::bail!("azure backend requires the `azure` feature")
             }
         }
     };

--- a/crates/walgit-store/tests/contract.rs
+++ b/crates/walgit-store/tests/contract.rs
@@ -6,9 +6,10 @@
 //! isolation, large streamed put/get roundtrip with checksum, and the
 //! multipart upload path.
 //!
-//! The suite is executed against `MemoryStore` always, and against `S3Store`
-//! when `WALGIT_TEST_S3_ENDPOINT` is set. `GcsStore` is tested when
-//! `WALGIT_TEST_GCS_BUCKET` is set (StoreGcs adds that wrapper).
+//! The suite is executed against `MemoryStore` always, against `S3Store`
+//! when `WALGIT_TEST_S3_ENDPOINT` is set, against `GcsStore` when
+//! `WALGIT_TEST_GCS_BUCKET` is set, and against `AzureStore` when
+//! `WALGIT_TEST_AZURE_ENDPOINT` is set.
 
 use std::ops::Range;
 use std::sync::Arc;
@@ -766,6 +767,102 @@ async fn gcs_contract() {
         let _ = store.delete(&m.key, None).await;
     }
     eprintln!("[gcs_contract] cleanup done ({count} objects deleted)");
+}
+
+#[cfg(feature = "azure")]
+#[tokio::test]
+async fn azure_contract() {
+    let endpoint = match std::env::var("WALGIT_TEST_AZURE_ENDPOINT") {
+        Ok(v) => v,
+        Err(_) => {
+            eprintln!("skipping azure_contract: WALGIT_TEST_AZURE_ENDPOINT not set");
+            return;
+        }
+    };
+    let account =
+        std::env::var("WALGIT_TEST_AZURE_ACCOUNT").unwrap_or_else(|_| "devstoreaccount1".into());
+    let bucket = std::env::var("WALGIT_TEST_BUCKET").unwrap_or_else(|_| "walgit-test".into());
+    let _key = std::env::var("AZURE_STORAGE_ACCOUNT_KEY")
+        .expect("AZURE_STORAGE_ACCOUNT_KEY required for Azure tests");
+
+    let prefix = format!("contract-test-{}", uuid::Uuid::new_v4().simple());
+    eprintln!(
+        "[azure_contract] endpoint={endpoint} account={account} container={bucket} prefix={prefix}"
+    );
+
+    let cfg = walgit_config::StoreConfig {
+        backend: walgit_config::StoreBackend::Azure,
+        bucket: bucket.clone(),
+        prefix: prefix.clone(),
+        azure: walgit_config::AzureConfig {
+            endpoint: endpoint.clone(),
+            account: account.clone(),
+            account_key_env: "AZURE_STORAGE_ACCOUNT_KEY".into(),
+            connection_string_env: "AZURE_STORAGE_CONNECTION_STRING_UNUSED".into(),
+            use_aad: false,
+        },
+        multipart_threshold: bytesize::ByteSize::mib(5),
+        multipart_part_size: bytesize::ByteSize::mib(4),
+        ..Default::default()
+    };
+
+    let store = walgit_store::azure::AzureStore::new(&cfg)
+        .await
+        .expect("AzureStore::new");
+    store
+        .ensure_container()
+        .await
+        .expect("ensure azure container");
+    let store: DynStore = Arc::new(store);
+
+    run_contract(store.clone(), &prefix).await;
+
+    // SAS: a URL without the account key must return the put bytes.
+    let sas_key = format!("{prefix}/sas-probe");
+    store
+        .put(
+            &sas_key,
+            PutBody::Bytes(Bytes::from_static(b"sas-body")),
+            PutOptions::from(PutMode::Overwrite),
+        )
+        .await
+        .expect("put sas probe");
+    let url = store
+        .signed_get_url(&sas_key, std::time::Duration::from_secs(3600))
+        .await
+        .expect("signed_get_url");
+    let url = url.expect("azure signed_get_url must return Some");
+    eprintln!(
+        "[azure_contract] sas url minted ({} bytes of url)",
+        url.len()
+    );
+    let resp = reqwest::Client::new()
+        .get(&url)
+        .send()
+        .await
+        .expect("sas GET");
+    let status = resp.status();
+    let body = resp.bytes().await.expect("sas body");
+    assert!(
+        status.is_success(),
+        "sas GET status {status} body {}",
+        String::from_utf8_lossy(&body)
+    );
+    assert_eq!(&body[..], b"sas-body", "sas GET body mismatch");
+
+    let to_delete: Vec<_> = futures::stream::iter(
+        walgit_store::ObjectStore::list(store.as_ref(), &prefix, None)
+            .collect::<Vec<_>>()
+            .await,
+    )
+    .filter_map(|r| async move { r.ok() })
+    .collect::<Vec<_>>()
+    .await;
+    let count = to_delete.len();
+    for m in &to_delete {
+        let _ = store.delete(&m.key, None).await;
+    }
+    eprintln!("[azure_contract] cleanup done ({count} objects deleted)");
 }
 
 /// Control plane must stay fast under bulk load (prod 2026-08-20: a 184-byte

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -23,7 +23,7 @@ Read `AGENTS.md` first (design §1–§2, decisions §3; the original layout/pha
   `GetResult::{NotModified,Object}`, `PutMode::{Overwrite,Create,Update(Version)}`, `PutBody::{Bytes,Stream,File}`,
   `PutOptions`, `StoreError::{NotFound,PreconditionFailed{current},Retryable,InvalidArgument,Other}`,
   `ObjectStoreExt`, `Prefixed`, `memory::MemoryStore`, `util::{collect,once,file_stream,backoff,retry}`),
-  placeholder modules `coord.rs`, `gcs.rs`, `s3.rs`.
+  placeholder modules `coord.rs`, `gcs.rs`, `s3.rs`, `azure.rs`.
 - `walgit-config`: `Config` for walgit.toml (+ `WALGIT__` env overrides, `PORT`); `Config::with_settings` accepts
   only `[bundles]`, `[maintenance]`, `[compaction]`, `[upstream]`, and `[integrations]` in repo-scoped settings.
 
@@ -159,12 +159,15 @@ pub enum CoordError { Store(StoreError), Decode(prost::DecodeError), Aborted, Re
 pub struct S3Store; impl S3Store { pub async fn new(cfg: &walgit_config::StoreConfig) -> anyhow::Result<Self>; }
 // gcs.rs
 pub struct GcsStore; impl GcsStore { pub async fn new(cfg: &walgit_config::StoreConfig) -> anyhow::Result<Self>; }
+// azure.rs
+pub struct AzureStore; impl AzureStore { pub async fn new(cfg: &walgit_config::StoreConfig) -> anyhow::Result<Self>; }
 // lib.rs
 pub async fn open_store(cfg: &walgit_config::Config) -> anyhow::Result<DynStore>; // by cfg.store.backend, applies Prefixed(cfg.store_prefix())
 ```
 Contract tests: `crates/walgit-store/tests/contract.rs` with a `run_contract(store: DynStore)` suite executed for
 memory always, for s3 when `WALGIT_TEST_S3_ENDPOINT` set (bucket `WALGIT_TEST_BUCKET`, default "walgit-test"),
-for gcs when `WALGIT_TEST_GCS_BUCKET` set.
+for gcs when `WALGIT_TEST_GCS_BUCKET` set, for azure when `WALGIT_TEST_AZURE_ENDPOINT` set (account
+`WALGIT_TEST_AZURE_ACCOUNT`, default `devstoreaccount1`; key `AZURE_STORAGE_ACCOUNT_KEY`).
 
 ## walgit-wal (owner: Wal)
 

--- a/justfile
+++ b/justfile
@@ -69,12 +69,23 @@ dev-store:
 dev-store-stop:
     podman compose down
 
+# Start Azurite (Azure Blob emulator) on :10000. Well-known account/key.
+dev-azurite:
+    podman compose up -d azurite
+    echo "Azurite blob is running on http://127.0.0.1:10000"
+    echo "Account: devstoreaccount1"
+    echo "Key: (Azurite well-known key; AZURE_STORAGE_ACCOUNT_KEY in just test-azure)"
+
+dev-azurite-stop:
+    podman compose stop azurite
+
 # --- tests -------------------------------------------------------------------
 # Tiers (all hermetic: in-memory store, tempdir caches, real `git` binary):
 #   test       fast tier, < 30 s: every unit/integration test not marked #[ignore]
 #   test-slow  benches/soak: #[ignore]d tests (20k-ref push, 466k-ref render, ...)
 #   test-s3    store contract against local rustfs (just dev-store)
 #   test-gcs   store contract against a real bucket (writes under a unique prefix)
+#   test-azure store contract against local Azurite (just dev-azurite)
 
 # Fast hermetic tier (< 30 s): every test not marked #[ignore].
 # Fast tier (default, < 1 min): unit tests + the quick integration suites.
@@ -123,7 +134,6 @@ test-gcs bucket:
 store-test:
     cargo test -p walgit-store --test contract -- memory_contract
 
-# Run walgit-store contract tests against rustfs (requires `just dev-store` first).
 # Store contract against local rustfs (run `just dev-store` first).
 test-s3: store-test-s3
 
@@ -134,6 +144,16 @@ store-test-s3:
     AWS_SECRET_ACCESS_KEY=walgit-dev-secret \
     cargo test -p walgit-store --test contract -- --nocapture
 
-# Run all walgit-store tests (memory + S3 if env set).
+# Store contract against local Azurite (run `just dev-azurite` first).
+test-azure: store-test-azure
+
+store-test-azure:
+    WALGIT_TEST_AZURE_ENDPOINT=http://127.0.0.1:10000 \
+    WALGIT_TEST_AZURE_ACCOUNT=devstoreaccount1 \
+    WALGIT_TEST_BUCKET=walgit-test \
+    AZURE_STORAGE_ACCOUNT_KEY=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw== \
+    cargo test -p walgit-store --features azure --test contract -- azure --nocapture
+
+# Run all walgit-store tests (memory plus configured env-gated backends).
 store-test-all:
     cargo test -p walgit-store

--- a/walgit.example.toml
+++ b/walgit.example.toml
@@ -65,7 +65,7 @@ anonymous_read = true             # must be false in oidc mode
 # trusted_forwarders = []                  # principals allowed to set X-Walgit-Principal (a front in front of a push broker)
 
 [store]
-backend = "s3"                    # "s3" (AWS, MinIO, rustfs, R2, Ceph, …) | "gcs" | "memory" (tests)
+backend = "s3"                    # "s3" (AWS, MinIO, rustfs, R2, Ceph, …) | "gcs" | "azure" | "memory" (tests)
 bucket = "walgit"
 prefix = ""                       # global key prefix inside the bucket
 max_retries = 8                   # retries on retryable store errors (jittered backoff)
@@ -85,6 +85,13 @@ direct_connectivity = true
 # signing_service_account = "sa@project.iam.gserviceaccount.com"   # for bundles/lfs serve_via = "signed_url"
 bulk_clients = 4                  # separate data channels for pack/idx/side-file/bundle/LFS bytes + ranged reads
 bulk_concurrency = 32             # max concurrent bulk requests per process (control plane never queues behind them)
+
+[store.azure]
+endpoint = ""                     # empty = https://{account}.blob.core.windows.net; Azurite: http://127.0.0.1:10000
+account = ""                      # storage account name; Azurite: devstoreaccount1
+account_key_env = "AZURE_STORAGE_ACCOUNT_KEY"   # env var names read at runtime; never a literal key in this file
+connection_string_env = "AZURE_STORAGE_CONNECTION_STRING"  # if that env is set it wins over account/key/endpoint
+use_aad = false                   # true = Entra ID (AKS workload identity, managed identity, then developer tools); SAS uses a user-delegation key
 
 [cache]
 dir = "/tmp/walgit"               # local materialized repos (+ tls/ for a self-signed certificate)

--- a/walgit.standalone.toml
+++ b/walgit.standalone.toml
@@ -66,6 +66,12 @@ force_path_style = true
 # backend = "gcs"
 # bucket = "my-walgit-bucket"
 # prefix = ""
+# Azure Blob (Azurite: just dev-azurite; account key in AZURE_STORAGE_ACCOUNT_KEY):
+# backend = "azure"
+# bucket = "walgit-test"
+# [store.azure]
+# endpoint = "http://127.0.0.1:10000"
+# account = "devstoreaccount1"
 
 # Bundles (docs/BUNDLE_URI_DESIGN.md): one weekly full, then **chained** incrementals — each daily on the
 # previous daily (the first on the weekly), each hourly on the previous hourly (restarting from every new


### PR DESCRIPTION
[👾 omp · openai-codex/gpt-5.6-sol · agency: delegated · intent: contribute Azure Blob support and AKS workload identity]

> **TL;DR:** walgit can use Azure Blob Storage as its durable ObjectStore and authenticate on AKS with native workload identity, without storing Azure credentials in config.

- **Problem:** walgit supports S3 and GCS, but Azure users cannot point the same binary at Blob Storage.
- **Outcome:** Azure Blob implements the existing ObjectStore contract, including CAS, range reads, block composition, and signed reads.
- **Scope:** Azure backend, configuration, dependencies, contract tests, local Azurite support, and concise documentation only.

## Why

Azure Blob Storage needs the same first-class store contract as S3 and GCS. AKS deployments also need an Entra credential that understands projected workload identity tokens instead of relying on account keys or a developer credential.

This reconstructs the Azure work from closed PR #1 / commit `573691c89b465053db3d31aac2154cb55ab5f59a` on current `main` (`113a0b24024734194f15d1523fde58add71c4f82`). It does not merge that orphaned history.

## What changed & how

1. Added `AzureStore` over the Azure Blob REST API.
   - Blob ETags remain opaque ObjectStore versions for conditional GET, create, update, and delete.
   - Range reads, streamed and block uploads, listing, deletion, compose, signed URLs, and acceleration targets implement the existing trait.
   - Compose uses Put Block From URL plus Put Block List. Azurite's unsupported copy operation falls back to fetching and uploading blocks; real Azure keeps the server-side path.
2. Added `store.backend = "azure"` and fail-closed Azure configuration.
   - `store.bucket` is the Blob container.
   - An empty endpoint resolves to `https://{account}.blob.core.windows.net`; custom endpoints use path-style addressing for Azurite.
   - Validation requires an account source and at least one configured credential source.
3. Added native Entra credential resolution.
   - `WorkloadIdentityCredential` is tried first for AKS.
   - Managed identity and developer tools follow for non-AKS environments.
   - Account-key and connection-string modes remain available for Azurite and explicit shared-key deployments.
4. Added the shared ObjectStore contract runner for Azure, an Azurite compose service and focused `just` recipes, feature wiring, dependency lock updates, examples, and store-contract documentation.

The old PR's Windows portability edits to CLI import, server rebuild, and WAL filesystem code are deliberately excluded. This branch also contains no deployment references, event batching, or generic subprocess changes.

## Security

- Account keys and connection strings are read from named environment variables; config contains variable names, never secret values.
- Shared-key credentials take precedence when present. Otherwise `use_aad = true` selects the Entra chain beginning with native AKS workload identity.
- Shared-key signed reads use service SAS. Entra signed reads use a user-delegation key and user-delegation SAS.
- Missing credentials fail store construction. Invalid Azure configuration fails `Config::validate`.
- No IAM role or Azure resource is created by this PR.

## How this was tested

1. `cargo check -p walgit-config -p walgit-store -p walgit-cli`
   - Passed on current upstream after fixing the workload credential clone path.
2. `cargo test -p walgit-config azure`
   - 6 passed; covers TOML/env parsing, unknown fields, workload-identity validation, and fail-closed account/credential validation.
3. `cargo test -p walgit-store --features azure --lib azure::tests`
   - 8 passed; covers endpoint shape, connection strings, ETags, list parsing, request canonicalization, and missing credentials.
4. `WALGIT_TEST_AZURE_ENDPOINT=http://127.0.0.1:10000 WALGIT_TEST_AZURE_ACCOUNT=devstoreaccount1 WALGIT_TEST_BUCKET=walgit-test AZURE_STORAGE_ACCOUNT_KEY=<Azurite well-known key> cargo test -p walgit-store --features azure --test contract -- azure --nocapture`
   - 1 passed against local Azurite: the shared ObjectStore contract plus an unauthenticated SAS GET.

Object-store protocol depth and request counts are unchanged: this adds a backend implementation for the existing operations rather than a new store round trip.

## Reviewer question

Should Entra authentication remain one `use_aad` switch with the fixed workload identity → managed identity → developer-tools order, or should Azure config select a single credential kind explicitly? This PR keeps the smaller surface from PR #1 and adds workload identity first.

## Unverified

- A real Azure Storage account was not available in this environment, so native Put Block From URL and real service/user-delegation SAS behavior were not exercised here.
- An AKS cluster was not available, so projected-token exchange through `WorkloadIdentityCredential` was compile-checked but not exercised against Entra.

The PR remains draft until those real-Azure and AKS paths are verified or maintainers accept the focused Azurite evidence.
