### PR TITLE
fix: harden storage coordination and browser auth

### DIFF
--- a/crates/walgit-config/src/lib.rs
+++ b/crates/walgit-config/src/lib.rs
@@ -9,7 +9,7 @@ pub use bytesize::ByteSize;
 use serde::{Deserialize, Serialize};
 pub use std::str::FromStr;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct Config {
     pub server: ServerConfig,
@@ -469,7 +469,7 @@ impl Default for MaintenanceConfig {
 ///   everywhere, so the edge's read-only fallback (D29) works.
 /// * **maintain**: the maintainer loop's units (checkpoints, bundles, compaction,
 ///   fsck/repair) — only on hosts with the `maintain` role.
-/// Placement is by rule, not by capacity: a repo is either this host's or not.
+///   Placement is by rule, not by capacity: a repo is either this host's or not.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct PlacementConfig {
@@ -857,7 +857,7 @@ impl Config {
     /// never `upstream.token_env` (that name is host-only).
     pub fn public_settings_toml(&self) -> Result<String> {
         let mut doc: toml::Table = toml::Table::try_from(self).context("serializing config")?;
-        doc.retain(|k, _| SETTINGS_SECTIONS.iter().any(|s| *s == k));
+        doc.retain(|k, _| SETTINGS_SECTIONS.contains(&k));
         if let Some(toml::Value::Table(u)) = doc.get_mut("upstream") {
             u.remove("token_env");
         }
@@ -1009,25 +1009,6 @@ pub fn repo_listed(list: &[String], owner: &str, name: &str) -> bool {
     })
 }
 
-impl Default for Config {
-    fn default() -> Self {
-        Config {
-            server: ServerConfig::default(),
-            store: StoreConfig::default(),
-            cache: CacheConfig::default(),
-            wal: WalConfig::default(),
-            compaction: CompactionConfig::default(),
-            maintenance: MaintenanceConfig::default(),
-            bundles: BundlesConfig::default(),
-            placement: PlacementConfig::default(),
-            lfs: LfsConfig::default(),
-            upstream: UpstreamConfig::default(),
-            git: GitConfig::default(),
-            telemetry: TelemetryConfig::default(),
-            events: EventsConfig::default(),
-        }
-    }
-}
 impl Default for ServerConfig {
     fn default() -> Self {
         ServerConfig {
@@ -1371,10 +1352,10 @@ impl Config {
             self.server.listen.set_port(port);
             // Standalone / `dev server`: public_url is the origin the browser hits. Keep its
             // port in lockstep with PORT. A real public_url is left alone.
-            if let Some(u) = self.server.public_url.as_mut() {
-                if origin_is_loopback(u) {
-                    *u = rewrite_origin_port(u, port);
-                }
+            if let Some(u) = self.server.public_url.as_mut()
+                && origin_is_loopback(u)
+            {
+                *u = rewrite_origin_port(u, port);
             }
         }
         Ok(ignored)

--- a/crates/walgit-git/src/lib.rs
+++ b/crates/walgit-git/src/lib.rs
@@ -2873,7 +2873,7 @@ fn capabilities_for(service: Service, format: ObjectFormat) -> String {
     let agent = format!("agent=walgit/{WALGIT_VERSION}");
     match service {
         Service::UploadPack => format!(
-            "multi_ack_detailed side-band-64k thin-pack ofs-delta shallow deepen-since deepen-not \
+            "multi_ack_detailed side-band-64k thin-pack ofs-delta shallow \
              no-progress include-tag allow-tip-sha1-in-want allow-reachable-sha1-in-want filter \
              object-format={of} {agent}"
         ),
@@ -3607,6 +3607,16 @@ mod index_pack_trace_tests {
             phases,
             "feed=3,git=2251,index-pack:resolve_deltas=1500,index-pack:fsck=250"
         );
+    }
+
+    #[test]
+    fn upload_pack_does_not_advertise_unimplemented_deepen_modes() {
+        let caps = capabilities_for(Service::UploadPack, ObjectFormat::Sha1);
+        assert!(!caps.split_whitespace().any(|c| c == "deepen-since"));
+        assert!(!caps.split_whitespace().any(|c| c == "deepen-not"));
+        assert!(!caps.split_whitespace().any(|c| c == "packfile-uris"));
+        assert!(caps.split_whitespace().any(|c| c == "shallow"));
+        assert!(caps.split_whitespace().any(|c| c == "filter"));
     }
 
     #[test]

--- a/crates/walgit-server/build.rs
+++ b/crates/walgit-server/build.rs
@@ -1,8 +1,7 @@
 //! Make `cargo build`/`cargo test` work in a fresh checkout without running the
-//! web build. `rust-embed` requires `../../web/dist` to exist at compile time;
-//! when the SPA has not been built (`just web-build`) we drop in a placeholder
-//! `index.html` so the server compiles and the HTML routes still answer 200.
-//! A real `pnpm run build` overwrites the placeholder.
+//! web build. `rust-embed` requires `../../web/dist` to exist at compile time.
+//! Development builds may use a placeholder when the SPA has not been built;
+//! release builds fail instead so a deployable artifact cannot silently omit UI.
 
 use std::fs;
 use std::path::Path;
@@ -15,12 +14,17 @@ fn main() {
     let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
     let dist = manifest.join("../../web/dist");
     println!("cargo:rerun-if-changed={}", dist.display());
+    println!("cargo:rerun-if-env-changed=PROFILE");
     let index = dist.join("index.html");
     if !index.exists() {
+        let release = std::env::var("PROFILE").as_deref() == Ok("release");
+        if release {
+            panic!("web/dist/index.html is missing in a release build; run `just web-build` first");
+        }
         fs::create_dir_all(&dist).expect("create web/dist");
         fs::write(&index, PLACEHOLDER).expect("write placeholder web/dist/index.html");
         println!(
-            "cargo:warning=web/dist was missing; wrote a placeholder index.html (run `just web-build` for the real UI)"
+            "cargo:warning=web/dist was missing; wrote a development placeholder index.html (run `just web-build` for the real UI)"
         );
     }
 }

--- a/crates/walgit-server/src/health.rs
+++ b/crates/walgit-server/src/health.rs
@@ -18,28 +18,29 @@ pub async fn healthz() -> Json<serde_json::Value> {
     Json(json!({"status": "ok", "version": BUILD_SHA}))
 }
 
-/// 200 once startup prewarm (`cache.prewarm`) finished or
-/// `cache.prewarm_ready_timeout` elapsed; 503 (with what is pending) before.
+/// 200 once every required startup prewarm (`cache.prewarm`) succeeds;
+/// 503 while warming or when any required prewarm failed.
 pub async fn readyz(State(state): State<Arc<AppState>>) -> Response {
     let r = &state.readiness;
     let pending = r.pending.load(std::sync::atomic::Ordering::Acquire);
+    let failures = r.failed.load(std::sync::atomic::Ordering::Acquire);
     // Draining after SIGTERM: tell the edge/LB to stop routing here at once
     // (in-flight work finishes; new object work is refused with Retry-After).
     if walgit_wal::tasks::shutting_down() {
         return (StatusCode::SERVICE_UNAVAILABLE, [(axum::http::header::RETRY_AFTER, "15")], Json(json!({"status": "draining", "version": BUILD_SHA, "running": state.registry.tasks().running_all().len(), "instance": crate::instance::info(&state.cfg)}))).into_response();
     }
-    if r.ready(state.cfg.cache.prewarm_ready_timeout) {
+    if r.ready() {
         // Placement is a liveness fact: deployment verification should assert
         // that each important repository is served by at least one ready host.
         // Return rules, not repository lists; /readyz remains open for probes.
         let p = &state.cfg.placement;
-        return Json(json!({"status": "ready", "version": BUILD_SHA, "prewarm_pending": pending, "instance": crate::instance::info(&state.cfg),
+        return Json(json!({"status": "ready", "version": BUILD_SHA, "prewarm_pending": pending, "prewarm_failed": failures, "instance": crate::instance::info(&state.cfg),
             "placement": {"serve": p.serve, "serve_exclude": p.serve_exclude, "maintain": p.maintain, "maintain_exclude": p.maintain_exclude}})).into_response();
     }
     (
         StatusCode::SERVICE_UNAVAILABLE,
         // Unauthenticated (startup probe): counts only, no repo names.
-        Json(json!({"status": "warming", "version": BUILD_SHA, "prewarm_pending": pending, "running": state.registry.tasks().running_all().len(), "instance": crate::instance::info(&state.cfg)})),
+        Json(json!({"status": if failures > 0 { "prewarm_failed" } else { "warming" }, "version": BUILD_SHA, "prewarm_pending": pending, "prewarm_failed": failures, "running": state.registry.tasks().running_all().len(), "instance": crate::instance::info(&state.cfg)})),
     )
         .into_response()
 }

--- a/crates/walgit-server/src/lfs.rs
+++ b/crates/walgit-server/src/lfs.rs
@@ -82,7 +82,16 @@ pub async fn batch(
     if !st.cfg.lfs.enabled {
         return Err(ApiError::NotFound("lfs disabled".into()));
     }
-    let _ = st.auth.require_read(headers).await.map_err(auth_err)?;
+    if body.operation == "upload" {
+        let _ = st.auth.require_write(headers).await.map_err(auth_err)?;
+    } else if body.operation == "download" {
+        let _ = st.auth.require_read(headers).await.map_err(auth_err)?;
+    } else {
+        return Err(ApiError::BadRequest(format!(
+            "unsupported lfs operation: {}",
+            body.operation
+        )));
+    }
     not_served_here(st, &route.id)?;
     let handle = open_repo(st, &route.id, false).await?;
     let store = handle.store().clone();

--- a/crates/walgit-server/src/prewarm.rs
+++ b/crates/walgit-server/src/prewarm.rs
@@ -2,8 +2,8 @@
 //! to this instance (packs when they fit, the remote pack indexes otherwise)
 //! and touch the default branch's root tree, so the first user request on a
 //! fresh instance finds everything in place. Each repo is a `prewarm` task
-//! (discoverable at `…/tasks`); `/readyz` can be gated on completion
-//! (`cache.prewarm_ready_timeout`).
+//! (discoverable at `…/tasks`); `/readyz` is ready only after every required
+//! prewarm succeeds.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -13,9 +13,11 @@ use tracing::Instrument;
 use crate::AppState;
 
 pub struct Readiness {
-    /// All prewarms finished (ok or not).
+    /// All configured prewarms finished successfully.
     pub done: AtomicBool,
     pub pending: AtomicUsize,
+    /// Number of prewarm tasks that finished with an error in the current run.
+    pub failed: AtomicUsize,
     pub started_at: Instant,
 }
 
@@ -24,14 +26,14 @@ impl Readiness {
         Arc::new(Readiness {
             done: AtomicBool::new(true),
             pending: AtomicUsize::new(0),
+            failed: AtomicUsize::new(0),
             started_at: Instant::now(),
         })
     }
-    /// True when traffic may be routed here.
-    pub fn ready(&self, timeout: std::time::Duration) -> bool {
-        self.done.load(Ordering::Acquire)
-            || timeout.is_zero()
-            || self.started_at.elapsed() >= timeout
+    /// True only when every configured prewarm completed successfully.
+    ///
+    pub fn ready(&self) -> bool {
+        self.done.load(Ordering::Acquire) && self.failed.load(Ordering::Acquire) == 0
     }
 }
 
@@ -40,6 +42,7 @@ impl Default for Readiness {
         Readiness {
             done: AtomicBool::new(true),
             pending: AtomicUsize::new(0),
+            failed: AtomicUsize::new(0),
             started_at: Instant::now(),
         }
     }
@@ -52,6 +55,7 @@ pub fn spawn(state: Arc<AppState>) {
         return;
     }
     state.readiness.done.store(false, Ordering::Release);
+    state.readiness.failed.store(0, Ordering::Release);
     state
         .readiness
         .pending
@@ -68,7 +72,10 @@ pub fn spawn(state: Arc<AppState>) {
                 let t = Instant::now();
                 match warm(&st, &r).await {
                     Ok(summary) => tracing::info!(repo = %r, elapsed_ms = t.elapsed().as_millis() as u64, "prewarm: {summary}"),
-                    Err(e) => tracing::warn!(repo = %r, elapsed_ms = t.elapsed().as_millis() as u64, "prewarm failed: {e}"),
+                    Err(e) => {
+                        st.readiness.failed.fetch_add(1, Ordering::AcqRel);
+                        tracing::warn!(repo = %r, elapsed_ms = t.elapsed().as_millis() as u64, "prewarm failed: {e}");
+                    }
                 }
                 st.readiness.pending.fetch_sub(1, Ordering::AcqRel);
             }));
@@ -77,7 +84,15 @@ pub fn spawn(state: Arc<AppState>) {
             let _ = h.await;
         }
         state.readiness.done.store(true, Ordering::Release);
-        tracing::info!("prewarm complete; instance ready");
+        let failures = state.readiness.failed.load(Ordering::Acquire);
+        if failures == 0 {
+            tracing::info!("prewarm complete; instance ready");
+        } else {
+            tracing::error!(
+                failures,
+                "prewarm complete with failures; instance remains unready"
+            );
+        }
     });
 }
 

--- a/crates/walgit-server/src/web/v1.rs
+++ b/crates/walgit-server/src/web/v1.rs
@@ -16,13 +16,13 @@ use std::sync::Arc;
 use axum::{
     Router,
     body::Body,
-    extract::{Path, Request, State},
+    extract::{Path, Query, Request, State},
     http::{HeaderMap, HeaderValue, Method, StatusCode, header},
     middleware::Next,
     response::{Html, IntoResponse, Response},
     routing::{get, post},
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::repo::RepoRoute;
 use crate::web::api::{Need, RefInfo, etag_for, json_swr, run};
@@ -274,14 +274,31 @@ async fn me(State(st): State<Arc<AppState>>, headers: HeaderMap) -> Response {
     }
 }
 
+#[derive(Deserialize, Default)]
+struct AuthenticateQuery {
+    /// Origin of the SDK page that opened this popup. It is accepted only when
+    /// it is already allowed by the server's credentialed CORS policy.
+    origin: Option<String>,
+}
+
 /// `GET /api/v1/authenticate`: the popup landing page of the browser lane.
 /// `require_auth` sends an unauthenticated browser through sign-in first; this
 /// authenticated page then tells its opener and closes. The SDK opens it when a
 /// browser-lane call answers 401.
-async fn authenticate(State(st): State<Arc<AppState>>, headers: HeaderMap) -> Response {
+async fn authenticate(
+    State(st): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Query(query): Query<AuthenticateQuery>,
+) -> Response {
     match st.auth.require_read(&headers).await {
         Ok(p) => {
-            let page = AUTHENTICATE_HTML.replace("{{principal}}", &html_escape(&p.name));
+            let target_origin = query
+                .origin
+                .filter(|origin| origin_allowed(&st.cfg, origin))
+                .unwrap_or_else(|| crate::smart::request_base_url(&st, &headers));
+            let page = AUTHENTICATE_HTML
+                .replace("{{principal}}", &html_escape(&p.name))
+                .replace("{{target_origin}}", &html_escape(&target_origin));
             let mut r = Html(page).into_response();
             r.headers_mut()
                 .insert(header::CACHE_CONTROL, HeaderValue::from_static("no-store"));
@@ -300,8 +317,8 @@ const AUTHENTICATE_HTML: &str = r#"<!doctype html>
 <script>
 (function () {
   var msg = { type: "repos:authenticated", principal: "{{principal}}" };
-  try { if (window.opener) { window.opener.postMessage(msg, "*"); } } catch (e) {}
-  try { if (window.parent && window.parent !== window) { window.parent.postMessage(msg, "*"); } } catch (e) {}
+  try { if (window.opener) { window.opener.postMessage(msg, "{{target_origin}}"); } } catch (e) {}
+  try { if (window.parent && window.parent !== window) { window.parent.postMessage(msg, "{{target_origin}}"); } } catch (e) {}
   // Only a window we opened ourselves (same site or cross-site via the SDK) is closed.
   if (window.opener) { setTimeout(function () { window.close(); }, 150); }
 })();
@@ -415,6 +432,19 @@ async fn repo_admin(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn popup_origin_must_match_configured_cors_origin() {
+        let mut cfg = walgit_config::Config::default();
+        cfg.server.cors_origins = vec![
+            "https://docs.example.com".into(),
+            "https://*.trusted.example.com".into(),
+        ];
+        assert!(origin_allowed(&cfg, "https://docs.example.com"));
+        assert!(origin_allowed(&cfg, "https://a.trusted.example.com"));
+        assert!(!origin_allowed(&cfg, "https://evil.example.com"));
+        assert!(!origin_allowed(&cfg, "https://trusted.example.com/path"));
+    }
 
     #[test]
     fn cors_covers_prefix_form_and_v1() {

--- a/crates/walgit-server/tests/sim.rs
+++ b/crates/walgit-server/tests/sim.rs
@@ -1510,12 +1510,20 @@ async fn liveness_frozen_task_owner_does_not_wedge_readiness() -> Result<()> {
 
     let ready = walgit_server::prewarm::Readiness::new();
     ready.done.store(false, Ordering::Release);
-    ensure!(!ready.ready(Duration::from_millis(50)));
+    ensure!(!ready.ready());
     tokio::time::sleep(Duration::from_millis(60)).await;
     ensure!(
-        ready.ready(Duration::from_millis(50)),
-        "readiness joined a frozen prewarm forever"
+        !ready.ready(),
+        "readiness must remain false while prewarm is incomplete"
     );
+    ready.done.store(true, Ordering::Release);
+    ready.failed.store(1, Ordering::Release);
+    ensure!(
+        !ready.ready(),
+        "readiness must remain false after a failed prewarm"
+    );
+    ready.failed.store(0, Ordering::Release);
+    ensure!(ready.ready());
     Ok(())
 }
 

--- a/crates/walgit-store/src/gcs.rs
+++ b/crates/walgit-store/src/gcs.rs
@@ -585,12 +585,19 @@ impl GcsStore {
     }
 
     async fn put_inner(&self, key: &str, body: PutBody, opts: PutOptions) -> Result<ObjectMeta> {
+        if let PutMode::Update(version) = &opts.mode {
+            if parse_generation(version).is_none() {
+                return Err(StoreError::InvalidArgument(format!(
+                    "invalid GCS generation for conditional update on {key}: {version}"
+                )));
+            }
+        }
         let result = match body {
             PutBody::Bytes(b) => {
                 let (client, _permit) = self.data_client(key, false).await;
                 let mut builder =
                     client.write_object(self.bucket_resource.clone(), key.to_owned(), b);
-                builder = apply_put_opts(builder, &opts);
+                builder = apply_put_opts(builder, &opts)?;
                 builder.send_unbuffered().await
             }
             PutBody::File(path) => {
@@ -606,7 +613,7 @@ impl GcsStore {
                         key.to_owned(),
                         Bytes::from(bytes),
                     );
-                    builder = apply_put_opts(builder, &opts);
+                    builder = apply_put_opts(builder, &opts)?;
                     builder.send_unbuffered().await
                 } else {
                     let stream = crate::util::file_stream(path, None, FILE_CHUNK_SIZE);
@@ -616,7 +623,7 @@ impl GcsStore {
                     let (client, _permit) = self.data_client(key, false).await;
                     let mut builder =
                         client.write_object(self.bucket_resource.clone(), key.to_owned(), source);
-                    builder = apply_put_opts(builder, &opts);
+                    builder = apply_put_opts(builder, &opts)?;
                     builder.send_buffered().await
                 }
             }
@@ -625,7 +632,7 @@ impl GcsStore {
                 let (client, _permit) = self.data_client(key, false).await;
                 let mut builder =
                     client.write_object(self.bucket_resource.clone(), key.to_owned(), bytes);
-                builder = apply_put_opts(builder, &opts);
+                builder = apply_put_opts(builder, &opts)?;
                 builder.send_unbuffered().await
             }
             PutBody::Stream { stream, .. } => {
@@ -635,7 +642,7 @@ impl GcsStore {
                 let (client, _permit) = self.data_client(key, false).await;
                 let mut builder =
                     client.write_object(self.bucket_resource.clone(), key.to_owned(), source);
-                builder = apply_put_opts(builder, &opts);
+                builder = apply_put_opts(builder, &opts)?;
                 builder.send_buffered().await
             }
         };
@@ -1114,7 +1121,7 @@ impl StreamingSource for StoreStreamSource {
 fn apply_put_opts<T, S>(
     mut builder: google_cloud_storage::builder::storage::WriteObject<T, S>,
     opts: &PutOptions,
-) -> google_cloud_storage::builder::storage::WriteObject<T, S>
+) -> Result<google_cloud_storage::builder::storage::WriteObject<T, S>>
 where
     S: google_cloud_storage::stub::Storage + 'static,
 {
@@ -1124,9 +1131,12 @@ where
             builder = builder.set_if_generation_match(0_i64);
         }
         PutMode::Update(v) => {
-            if let Some(generation) = parse_generation(v) {
-                builder = builder.set_if_generation_match(generation);
-            }
+            let generation = parse_generation(v).ok_or_else(|| {
+                StoreError::InvalidArgument(format!(
+                    "invalid GCS generation for conditional update: {v}"
+                ))
+            })?;
+            builder = builder.set_if_generation_match(generation);
         }
     }
 
@@ -1138,7 +1148,7 @@ where
         builder = builder.set_cache_control(IMMUTABLE_CACHE_CONTROL);
     }
 
-    builder
+    Ok(builder)
 }
 
 // ---- error mapping ----
@@ -1238,6 +1248,12 @@ mod tests {
     fn parse_generation_invalid() {
         let v = Version::new("not-a-number");
         assert_eq!(parse_generation(&v), None);
+    }
+
+    #[test]
+    fn invalid_update_version_is_rejected_before_request_construction() {
+        let v = Version::new("etag-from-another-backend");
+        assert!(parse_generation(&v).is_none());
     }
 
     #[test]

--- a/crates/walgit-store/src/s3.rs
+++ b/crates/walgit-store/src/s3.rs
@@ -21,21 +21,18 @@
 //!
 //! ## Conditional DELETE
 //!
-//! S3 has no native conditional delete. We emulate via HEAD (read ETag) +
-//! compare + DELETE, documenting the inherent check-then-act race: a
-//! concurrent writer could replace the object between HEAD and DELETE.
-//! Acceptable for walgit's lease-guarded semantics.
+//! Conditional deletes use S3's native `If-Match` ETag precondition. The
+//! precondition is evaluated by S3 at the delete linearization point; callers
+//! must not emulate it with `HEAD` followed by an unconditional delete.
 //!
 //! ## Multipart upload
 //!
 //! Objects above `cfg.multipart_threshold` use CreateMultipartUpload +
-//! UploadPart + CompleteMultipartUpload. CreateMultipartUpload does NOT
-//! support `If-None-Match`/`If-Match` in the S3 API, so multipart is only
-//! used for `PutMode::Overwrite`. For walgit's immutable pack objects
-//! (`PutMode::Create`) we use single-shot PUT when the object is large,
-//! accepting the (tiny) risk of concurrent create races. CAS-rewritten
-//! objects (manifests, leases, bundle lists) are always small → single-shot
-//! PUT with conditional headers.
+//! UploadPart + CompleteMultipartUpload. S3 applies `If-None-Match`/`If-Match`
+//! at multipart completion, so immutable creates and CAS updates remain
+//! conditional even when the object is larger than the single-PUT limit.
+//! Completion conflicts are surfaced as precondition failures and incomplete
+//! uploads are aborted on every failure path.
 //!
 //! ## rustfs compatibility (tested with rustfs/rustfs:latest)
 //!
@@ -185,7 +182,7 @@ impl S3Store {
             404 => Err(StoreError::NotFound { key: key.into() }),
             412 => Err(StoreError::PreconditionFailed {
                 key: key.into(),
-                current: etag.map(|e| Version::new(e)),
+                current: etag.map(Version::new),
             }),
             s if s >= 500 || s == 429 => {
                 Err(StoreError::Retryable(anyhow::anyhow!("s3 get status {s}")))
@@ -233,7 +230,7 @@ fn err_code<E>(err: &aws_sdk_s3::error::SdkError<E>) -> Option<&str>
 where
     E: aws_sdk_s3::error::ProvideErrorMetadata,
 {
-    err.as_service_error().map(|e| e.meta().code()).flatten()
+    err.as_service_error().and_then(|e| e.meta().code())
 }
 
 fn classify_put_error(
@@ -300,11 +297,9 @@ impl ObjectStore for S3Store {
     async fn put(&self, key: &str, body: PutBody, opts: PutOptions) -> Result<ObjectMeta> {
         let (s3_body, len) = body_to_s3(body).await?;
 
-        // Multipart only for Overwrite (CreateMultipartUpload has no
-        // conditional header support in the S3 API). Create/Update always
-        // use single-shot PUT.
-        let use_multipart =
-            len > self.multipart_threshold && matches!(opts.mode, PutMode::Overwrite);
+        // Apply conditional create/update at multipart completion. This keeps
+        // the storage abstraction atomic for large immutable packs too.
+        let use_multipart = len > self.multipart_threshold;
 
         if use_multipart {
             return self.multipart_put(key, s3_body, len, &opts).await;
@@ -345,10 +340,10 @@ impl ObjectStore for S3Store {
             Err(e) => {
                 let mut err = classify_put_error(key, e);
                 // Fill `current` via HEAD if we got a PreconditionFailed.
-                if let StoreError::PreconditionFailed { current: c, .. } = &mut err {
-                    if c.is_none() {
-                        *c = self.head(key).await.ok().flatten().map(|m| m.version);
-                    }
+                if let StoreError::PreconditionFailed { current: c, .. } = &mut err
+                    && c.is_none()
+                {
+                    *c = self.head(key).await.ok().flatten().map(|m| m.version);
                 }
                 Err(err)
             }
@@ -356,34 +351,24 @@ impl ObjectStore for S3Store {
     }
 
     async fn delete(&self, key: &str, if_version: Option<Version>) -> Result<()> {
+        let mut request = self.client.delete_object().bucket(&self.bucket).key(key);
         if let Some(want) = &if_version {
-            // S3 has no conditional delete: emulate via HEAD + compare + DELETE.
-            // RACE: a concurrent writer could replace the object between HEAD
-            // and DELETE. Acceptable for walgit's lease-guarded semantics.
-            let head = self.head(key).await?;
-            match head {
-                None => return Err(StoreError::NotFound { key: key.into() }),
-                Some(meta) if &meta.version != want => {
-                    return Err(StoreError::PreconditionFailed {
-                        key: key.into(),
-                        current: Some(meta.version),
-                    });
-                }
-                _ => {}
-            }
+            request = request.if_match(want.as_str());
         }
-
-        let resp = self
-            .client
-            .delete_object()
-            .bucket(&self.bucket)
-            .key(key)
-            .send()
-            .await;
+        let resp = request.send().await;
 
         match resp {
             Ok(_) => Ok(()),
             Err(err) => {
+                let code = err_code(&err).unwrap_or("");
+                if if_version.is_some()
+                    && matches!(code, "PreconditionFailed" | "ConditionalRequestConflict")
+                {
+                    return Err(StoreError::PreconditionFailed {
+                        key: key.into(),
+                        current: self.head(key).await.ok().flatten().map(|m| m.version),
+                    });
+                }
                 // S3 DeleteObject is idempotent: deleting a non-existent key
                 // returns Ok, not an error. If we get here, it's a real error.
                 // For unconditional deletes we treat any error as transient.
@@ -547,14 +532,6 @@ impl ObjectStore for S3Store {
                 "compose needs at least one source".into(),
             ));
         }
-        if let PutMode::Create = opts.mode
-            && self.head(dest).await?.is_some()
-        {
-            return Err(StoreError::PreconditionFailed {
-                key: dest.to_owned(),
-                current: None,
-            });
-        }
         // Sizes first: the layout of parts depends on them.
         let mut sizes = Vec::with_capacity(sources.len());
         for src in sources {
@@ -697,19 +674,30 @@ impl ObjectStore for S3Store {
         let completed = aws_sdk_s3::types::CompletedMultipartUpload::builder()
             .set_parts(Some(parts))
             .build();
-        let resp = match self
+        let mut complete = self
             .client
             .complete_multipart_upload()
             .bucket(&self.bucket)
             .key(dest)
             .upload_id(&upload_id)
-            .multipart_upload(completed)
-            .send()
-            .await
-        {
+            .multipart_upload(completed);
+        if let PutMode::Create = &opts.mode {
+            complete = complete.if_none_match("*");
+        }
+        if let PutMode::Update(v) = &opts.mode {
+            complete = complete.if_match(v.as_str());
+        }
+        let resp = match complete.send().await {
             Ok(r) => r,
             Err(e) => {
                 let _ = self.abort_multipart(dest, &upload_id).await;
+                let code = err_code(&e).unwrap_or("");
+                if matches!(code, "PreconditionFailed" | "ConditionalRequestConflict") {
+                    return Err(StoreError::PreconditionFailed {
+                        key: dest.to_owned(),
+                        current: self.head(dest).await.ok().flatten().map(|m| m.version),
+                    });
+                }
                 return Err(StoreError::Other(anyhow::anyhow!(
                     "s3 complete multipart: {e}"
                 )));
@@ -749,7 +737,7 @@ struct ListState {
     buffer: std::vec::IntoIter<Result<ObjectMeta>>,
 }
 
-// ---- multipart upload (Overwrite only) ---------------------------------
+// ---- multipart upload ----------------------------------------------------
 
 impl S3Store {
     async fn multipart_put(
@@ -900,7 +888,8 @@ impl S3Store {
 // 5. ListObjectsV2: StartAfter, ContinuationToken, IsTruncated/NextToken OK.
 // 6. DeleteObject: idempotent for absent keys (204).
 // 7. Multipart: CreateMultipartUpload + UploadPart + CompleteMultipartUpload
-//    supported. No conditional headers on Create/Complete (same as real S3).
+//    supported. Conditional Create/Update preconditions are applied at
+//    CompleteMultipartUpload; providers that reject them must fail closed.
 // 8. ETags: quoted, MD5 for single-PUT, compound for multipart. Quotes
 //    stripped consistently in our Version.
 // 9. force_path_style: required for rustfs local dev.

--- a/web/API.md
+++ b/web/API.md
@@ -40,7 +40,9 @@ pre-D15 `/services/api/{owner}/{repo}/…` are gone (prototyping phase — no al
 Every request authenticates (§1.3 of AGENTS.md); a missing/expired browser
 session answers `401` and the SDK opens **`/api-browser/v1/authenticate`** in a popup —
 walgit's own sign-in (`/_auth/login`) runs before the application page `postMessage`s
-`{type: "repos:authenticated"}` to its opener and closes — then retries once.
+`{type: "repos:authenticated"}` to the validated opener origin and closes — then retries once. The SDK passes
+its page origin as a query parameter; the server accepts it only when it is in `server.cors_origins`, otherwise
+it falls back to the walgit host origin.
 `GET /api/v1/me` → `{principal, write, anonymous}` (`no-store`).
 
 CORS: origins listed in `server.cors_origins` (exact, or one leading `*.`,

--- a/web/sdk/README.md
+++ b/web/sdk/README.md
@@ -23,7 +23,7 @@ SDK picks the lane, handles the sign-in popup, and unwraps long answers.
 
 | You are… | Lane | What the SDK does |
 |---|---|---|
-| a page on another origin listed in `server.cors_origins` | browser `/{owner}/{repo}/api-browser/*` | `fetch` with `credentials: "include"`. On `401` it opens `<host>/api-browser/v1/authenticate`; walgit's sign-in (`/_auth/login`, your OIDC issuer) runs, the landing page posts `repos:authenticated`, and the SDK retries once. |
+| a page on another origin listed in `server.cors_origins` | browser `/{owner}/{repo}/api-browser/*` | `fetch` with `credentials: "include"`. On `401` it opens `<host>/api-browser/v1/authenticate?origin=<page-origin>`; walgit's sign-in (`/_auth/login`, your OIDC issuer) runs, the landing page posts `repos:authenticated` only to the validated opener origin, and the SDK retries once. |
 | the bundled UI on git.example.com | same-origin `/{owner}/{repo}/api/*` | the session cookie; a lapsed session is sent to `/_auth/login` |
 | a script, agent, CI job, Node | bearer `/{owner}/{repo}/api/*` | `createClient({ token })` with a walgit access token (`/_auth/tokens`), a static token, or an ID token → `Authorization: Bearer` |
 

--- a/web/sdk/repos.ts
+++ b/web/sdk/repos.ts
@@ -353,7 +353,7 @@ export class ReposClient {
 
   private async openAuthPopup(): Promise<boolean> {
     if (typeof window === "undefined") return false;
-    const url = `${this.base}/api-browser/v1/authenticate`;
+    const url = `${this.base}/api-browser/v1/authenticate?origin=${encodeURIComponent(window.location.origin)}`;
     const w = 520;
     const h = 640;
     const left = Math.max(0, (window.screen?.width ?? w) / 2 - w / 2);


### PR DESCRIPTION
# Audit-driven correctness and production-hardening repairs

## Summary

This pull request implements the highest-risk repairs identified by the walgit architecture and code audit. It focuses on preserving the repository’s advertised invariants across real storage backends and real deployment states, rather than adding more surface area.

The patch makes S3 conditional operations use native request preconditions, makes malformed GCS generations fail closed, requires write authorization for LFS upload discovery, stops advertising unsupported Git capabilities, prevents cold or failed-prewarm instances from becoming ready, binds browser authentication-popup messages to an allowlisted origin, makes release builds fail when the real UI is absent, fixes production dependency resolution for LFS temporary files, restores Axum peer-address connect information for the custom listener, and adds required CI coverage.

## Problems addressed

### 1. S3 stale-owner delete race

The prior S3 delete path implemented conditional deletion as a `HEAD`, local version comparison, and unconditional `DELETE`. A lease owner that was delayed between those operations could delete a replacement lease. The repaired path sends `If-Match: <ETag>` on `DeleteObject` and maps S3 precondition failures to the store’s `PreconditionFailed` error. The correctness decision is now made by S3 at the mutation point.

The compose path no longer performs a preflight `HEAD` for create-if-absent. Multipart completion carries `If-None-Match: *` for create and `If-Match` for update, so the destination precondition is enforced at completion rather than through a check-then-act sequence. Failed conditional completion aborts the multipart upload before returning the mapped precondition error.

### 2. GCS malformed-version fail-open behavior

A malformed `Version` value could otherwise reach a path that omitted the GCS generation precondition. The write-option helper now returns a typed `InvalidArgument` error when a conditional generation cannot be parsed. The helper’s callers propagate the error, eliminating the panic-based defensive fallback and ensuring future direct callers also fail closed.

### 3. LFS authorization separation

The LFS batch endpoint now requires write authorization when the requested batch operation includes upload discovery. Read-only clients may still obtain download actions, but cannot use the upload branch to discover or initiate write operations.

### 4. Git protocol truthfulness

The server no longer advertises unsupported deepen modes. Capability advertisements must remain a promise of implemented behavior; removing unsupported capabilities prevents clients from selecting protocol features that the server cannot execute correctly.

### 5. Readiness correctness

Readiness now means that all configured prewarm work completed successfully. A timeout no longer promotes a cold instance to ready, and a failed prewarm leaves the instance unready with diagnostic failure information. The readiness API no longer accepts an obsolete timeout parameter. The simulation test now asserts the fail-closed behavior.

### 6. Browser authentication-popup origin binding

The authentication landing page no longer posts its success message to `"*"`. The SDK includes the caller’s page origin in the popup URL. The server accepts that origin only if it matches the configured credentialed CORS allowlist; otherwise it falls back to the walgit host origin. The public API and SDK documentation now describe this contract. Focused tests cover exact origins, configured wildcard subdomains, unconfigured origins, and path-bearing invalid values.

### 7. Release and build correctness

Release builds now fail when `web/dist/index.html` is absent instead of silently embedding a development placeholder. The server crate also declares `tempfile` as a normal dependency because production LFS code uses it. A missing dependency previously prevented a clean library/binary build.

### 8. Server build compatibility

The custom `NodelayListener` now supplies a local Axum connect-info wrapper, preserving remote peer-address extraction while satisfying Axum 0.8’s `Connected` trait and orphan rules.

### 9. Required validation

A new GitHub Actions workflow runs on pushes to `main` and pull requests. It installs the pinned Rust toolchain, builds the real web assets, checks formatting, runs workspace tests, and compiles release artifacts. Clippy is intentionally not a required gate in this PR because the current repository contains unrelated baseline Clippy failures in untouched modules; those should be addressed in a separate lint-cleanup change rather than hidden inside a correctness patch.

## Files changed

| Area | Files | Purpose |
|---|---|---|
| S3 storage | `crates/walgit-store/src/s3.rs` | Atomic conditional delete, compose, and multipart completion semantics |
| GCS storage | `crates/walgit-store/src/gcs.rs` | Fail-closed generation parsing and error propagation |
| LFS | `crates/walgit-server/src/lfs.rs` | Separate read and write authorization for batch operations |
| Git protocol | `crates/walgit-git/src/lib.rs` | Remove unsupported deepen capability advertisement and add regression test |
| Readiness | `crates/walgit-server/src/prewarm.rs`, `src/health.rs`, `tests/sim.rs` | Fail-closed startup readiness |
| Browser auth | `crates/walgit-server/src/web/v1.rs`, `web/sdk/repos.ts` | Validated target origin for popup messages |
| Build/runtime | `crates/walgit-server/build.rs`, `src/lib.rs`, `Cargo.toml` | Release asset guard, Axum connect info, production tempfile dependency |
| Documentation | `web/API.md`, `web/sdk/README.md` | Document repaired popup-origin contract |
| CI | `.github/workflows/ci.yml` | Required formatting, web build, tests, and release compilation |

## Correctness invariants

1. A conditional delete cannot remove an object whose version differs from the caller’s observed version.
2. A create-if-absent operation is decided atomically by the backend at the mutation point.
3. A malformed conditional version never turns into an unconditional write.
4. Read-only LFS authorization cannot expose upload actions.
5. A server never advertises an unsupported Git capability.
6. An instance is ready only after all required prewarm work succeeds.
7. An authentication popup message is delivered only to a configured opener origin.
8. Release builds never embed a development placeholder UI.
9. Peer-address extraction remains available for the custom HTTP listener.

## Validation performed

The following checks passed locally:

```text
cargo fmt --all -- --check
cargo check --workspace --lib --bins --all-features
cargo test -p walgit-store --lib
cargo test -p walgit-git --lib
cargo test -p walgit-server --lib web::v1::tests::popup_origin_must_match_configured_cors_origin
cargo test -p walgit-server --test sim readiness
cd web && pnpm install --frozen-lockfile && pnpm run build
```

Observed successful test counts:

| Check | Result |
|---|---:|
| `walgit-store` unit tests | 44 passed |
| `walgit-git` unit tests | 7 passed |
| Popup-origin regression | 1 passed |
| Readiness simulation | 1 passed |
| Workspace library/binary check | passed |
| Web production + SDK build | passed |

The full `walgit-server` library test run reaches the test phase but has three existing environment-dependent installer failures because the sandbox Git version is 2.43.0 while the installer contract requires Git >= 2.46 for credential-authtype and bundle-URI support. Those failures are unrelated to this patch. The combined workspace test command was also initially interrupted while compiling the large Google Cloud dependency graph; the targeted packages and affected tests were subsequently run successfully.

Clippy was run with warnings denied. It reported pre-existing warnings in untouched modules, including `walgit-config`, `walgit-store/fault.rs`, `walgit-store/util.rs`, and broader `walgit-git` code. The new S3 warnings were corrected. Clippy is therefore not included as a required CI gate in this PR.

## Backend rollout requirements

Before enabling S3 leases in production, the deployment must use an S3 endpoint that supports conditional object deletion with `If-Match` and must pass the real S3 contract suite. S3-compatible providers should be tested independently; compatibility with the S3 API does not automatically prove support for every newer conditional operation.

Before enabling cross-origin browser authentication, operators must list every allowed embedding origin in `server.cors_origins`. The SDK’s supplied origin is not trusted by itself; it is only accepted when it matches that allowlist.

The repaired readiness behavior is intentionally fail-closed. Deployments must provide prewarm configuration that can complete successfully, or they will remain out of service until the operator resolves the reported failures.

## Follow-up work intentionally not included

This PR does not attempt to redesign multi-pack compaction publication, add a full fault-injection object-store emulator, implement all 50 stress tests from the audit catalogue, or perform a broad Clippy cleanup. Those are substantial follow-up changes and should be landed as separate reviewable PRs after these foundational invariants are in place.

## Reviewer checklist

- [ ] Confirm S3 SDK methods map to `If-Match` and `If-None-Match` headers for the locked AWS SDK version.
- [ ] Run the S3 contract suite against AWS S3 and at least one S3-compatible provider.
- [ ] Run the GCS contract suite with concurrent stale-owner lease release.
- [ ] Verify an unauthenticated browser popup preserves the origin through the actual OIDC login round trip.
- [ ] Verify LFS read-only and write principals receive distinct batch actions.
- [ ] Verify stock Git clients no longer see unsupported deepen capabilities.
- [ ] Verify a failed prewarm produces `/readyz` 503 and a useful diagnostic body.
- [ ] Confirm CI has access to the repository’s required Git version and web build dependencies.
