### PR TITLE
Add Azure Blob Storage backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,8 +144,8 @@ machines whose "disk" is 20 GiB of tmpfs, next to a long tail of small repositor
 | `fsck.pb` | Last connectivity audit (`FsckReport`), written by the maintainer's `fsck` unit, consumed by `repair` (`docs/INTEGRITY.md`). |
 | `events/cursor.json` | Durable acknowledged WAL sequence of the events bridge; advanced only after the webhook acknowledged (D32). |
 | `lfs/objects/<aa>/<bb>/<oid>` | LFS objects (sha256-addressed, immutable). Missing ones can be read through from `upstream.lfs` and persisted (`docs/LFS.md`). |
-Schema `crates/walgit-proto/proto/walgit/v1/wal.proto`; GCS over gRPC, S3 (AWS SDK) and in-memory stores share
-one contract suite (`crates/walgit-store/tests/contract.rs`, incl. compose).
+Schema `crates/walgit-proto/proto/walgit/v1/wal.proto`; GCS over gRPC, S3 (AWS SDK), Azure Blob REST and
+in-memory stores share one contract suite (`crates/walgit-store/tests/contract.rs`, incl. compose).
 
 ### 2.2 Write path
 receive-pack (ours, `walgit-git/src/receive.rs`) → index the pack locally (`git index-pack --stdin --fix-thin
@@ -222,7 +222,7 @@ changes take effect by re-planning; there are no one-off backfill scripts.
 
 ### 2.6 Bundles (bundle-uri): move clone bytes to static files — **the north star** (`docs/BUNDLE_URI_DESIGN.md`)
 - Strategies (config, D21/D22): **weekly full** (for a big repo = base pack ∘ header via store-side compose — GCS
-  natively, S3 by multipart `UploadPartCopy`; no disk, no index-pack), **daily incremental** chained on the previous
+  natively, S3 by multipart `UploadPartCopy`, Azure by `Put Block From URL`; no disk, no index-pack), **daily incremental** chained on the previous
   daily, **hourly incremental** on the newest daily, each on a calendar slot (6-field UTC cron `schedule`; the fire
   time is the as-of instant), `creationToken = slot epoch`, main-only refs for `bundles.main_only` repos;
   `bundles/list.pb` CAS'd.
@@ -275,9 +275,9 @@ decision in §4 — or the PR is; never "fix later".
   table per chunk per thread (60 M entries × 44 threads ⇒ 178 GB RSS) and is the only place gix writes an object id
   into a pack (a mid-pack refresh once paired offsets with another pack's table ⇒ a wrong id). The gix pack source
   is a frozen snapshot (`frozen_pack_source`). Reproducer: `walgit-git/tests/upload_gix_scale.rs`.
-- **D3** `ObjectStore` trait with CAS version tokens, conditional GET, range, compose; gcs/s3/memory backends.
-  `compose` is native on GCS and a multipart `UploadPartCopy` on S3 (`compose_is_native` tells callers which);
-  `accel_target` gives an edge a URL (+ bearer on GCS, presigned on S3) to fetch an object itself.
+- **D3** `ObjectStore` trait with CAS version tokens, conditional GET, range, compose; gcs/s3/azure/memory backends.
+  `compose` is native on GCS, multipart `UploadPartCopy` on S3, and `Put Block From URL` on Azure
+  (`compose_is_native` tells callers which); `accel_target` returns the backend's authenticated object URL.
 - **D4** protobuf on the wire and in the bucket; schema versioned, append-only.
 - **D5** Repo identity `<owner>/<repo>[.git]`, prefix `repos/<o>/<r>/`, creation = CAS create of the manifest.
 - **D6** Manifest CAS is the only commit point. **D7** No node identity, no elections; leases for exclusivity.
@@ -399,6 +399,9 @@ decision in §4 — or the PR is; never "fix later".
   + chain) is for clones, **`bundles/catchup`** (no fulls) is what recipes record in `fetch.bundleURI`. Measured: a
   catch-up is exactly the slots missed; for a client fetching several times a day, upload-pack's thin pack is
   smaller than an hourly bundle — bundles pay off for fresh clones and far-behind clients.
+- **D42** **Azure Blob Storage is a first-class ObjectStore backend** (2026-08-25). Authentication is explicit:
+  `store.azure.credential = "workload_identity"` uses AKS Workload Identity; `"account_key"` reads
+  `store.azure.account_key_env` for Azurite and service SAS signing. Azurite compose uses bounded process I/O.
 
 Decision identifiers are stable; gaps in the numbering are intentional.
 
@@ -423,8 +426,8 @@ Decision identifiers are stable; gaps in the numbering are intentional.
 - **Standalone first (D39):** a feature must work with walgit hit directly (no edge, in-process TLS, bytes
   streamed by walgit). Anything an edge takes over is announced per request in `X-Walgit-Capabilities`; never
   infer an edge from config, never hardcode a hostname in `crates/` or `web/`.
-- **S3 and GCS are both first class.** Every store feature has both implementations and runs in the contract
-  suite (`just test-s3` against rustfs, `just test-gcs <bucket>`); "GCS only" is a bug.
+- **S3, GCS and Azure Blob are first class.** Every store feature has all three implementations and runs in the
+  contract suite (`just test-s3`, `just test-gcs <bucket>`, `just test-azure`); a single-backend path is a bug.
 - **Use the rig before prod** (`just dev-store` → `walgit-server --config walgit.standalone.toml`). Per-repo
   settings (D24) with minute-scale slots compress a week of bundle behaviour into 30 minutes.
 - No new auth paths (§1.3). No LIST on hot paths. No unbounded buffering of packs in memory. No full

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,6 +753,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "azure_core"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e41cbd819986ba41904c207d8ffc4106f8f8352a548d773e9554906379bb2fb"
+dependencies = [
+ "async-lock",
+ "async-trait",
+ "azure_core_macros",
+ "bytes",
+ "futures",
+ "pin-project",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "typespec",
+ "typespec_client_core",
+]
+
+[[package]]
+name = "azure_core_macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9b52dba6a345f3ad2d42ff8d0d63df9d0994cfa29657bf18ffdbf149f78a4f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "tracing",
+]
+
+[[package]]
+name = "azure_identity"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32edf96b356ca7c51d7590c4925cc36efc3947a5da4468e8e0b25c56ecbb3de5"
+dependencies = [
+ "async-lock",
+ "async-trait",
+ "azure_core",
+ "futures",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "time",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5674,6 +5725,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "typespec"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "753a2fe021e407d4fc9ee6f4f0a33403cc306d5c54c4e4ebe1b8cbde0ca052b9"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "typespec_client_core"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0373af0f9d4f580b3a1a9d9639cedaabe015ed262b35bfbe13941bfb14fe1ea6"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "dyn-clone",
+ "futures",
+ "pin-project",
+ "rand 0.10.2",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "time",
+ "tokio",
+ "tracing",
+ "typespec",
+ "typespec_macros",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "typespec_macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c608f4427943f8adb211abc95c87672b1b98847152783507d54e3246e502f60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "uluru"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5979,13 +6081,18 @@ dependencies = [
  "aws-sdk-s3",
  "aws-smithy-types",
  "axum",
+ "azure_core",
+ "azure_identity",
+ "base64",
  "bytes",
  "bytesize",
+ "chrono",
  "futures",
  "google-cloud-auth",
  "google-cloud-gax",
  "google-cloud-storage",
  "hex",
+ "hmac 0.12.1",
  "http 1.5.0",
  "metrics",
  "parking_lot",
@@ -5995,6 +6102,7 @@ dependencies = [
  "rustls 0.23.43",
  "serde",
  "sha1 0.10.7",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,8 @@ google-cloud-auth = "1"
 aws-config = { version = "1", features = ["behavior-version-latest"] }
 aws-sdk-s3 = "1"
 aws-smithy-types = "1"
+azure_core = "1"
+azure_identity = "1"
 clap = { version = "4", features = ["derive", "env"] }
 rand = "0.9"
 sha1 = "0.10"

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # walgit — a git server that is one binary in front of an object store
 
 walgit hosts git repositories with **no database, no leader and no local state that matters**. You run a
-single binary, point it at an S3 or GCS bucket, and you have: smart HTTP (v0/v2) fetch and push, `bundle-uri`
+single binary, point it at an S3, GCS or Azure Blob bucket, and you have: smart HTTP (v0/v2) fetch and push, `bundle-uri`
 clones served as static files, Git LFS, a browsing web UI, a JSON API with an SDK, per-repository push policy,
 webhooks — and a server that scales to repositories **larger than the machine it runs on**. Every machine that
 runs walgit is a disposable cache; the bucket is the repository.
 
 ```sh
-# 1. a bucket (any S3-compatible store or GCS) and a config
+# 1. a bucket (any S3-compatible store, GCS or Azure Blob) and a config
 cat > walgit.toml <<'EOF'
 [server]
 listen = "0.0.0.0:8080"
@@ -79,7 +79,7 @@ server entirely (**bundle-uri**: fresh clones and catch-ups are static files the
 | **events** | A small bridge tails the WAL and POSTs ref events to a webhook, exactly-once per (repo, seq, ref) with a durable cursor. `docs/EVENTS.md`. |
 | **maintenance** | Checkpoints, bundle builds, geometric compaction, base rebuilds, connectivity audits and repairs — one loop that computes the desired state from (config, WAL) every pass and does one bounded unit of the most important missing work. Self-healing by construction: an outage leaves no holes; a deleted artefact is "missing" and rebuilt identically. |
 | **auth** | `none` (loopback), `token` (static tokens), `oidc` (any OpenID Connect issuer: browser sign-in, ID tokens, and walgit-issued access tokens for git). `/services/public/install.sh` sets a developer's machine up in one idempotent command. |
-| **stores** | S3 and S3-compatible (AWS, MinIO, rustfs, R2, Ceph, …) and GCS, first class; an in-memory store for tests. |
+| **stores** | S3 and S3-compatible (AWS, MinIO, rustfs, R2, Ceph, …), GCS and Azure Blob, first class; an in-memory store for tests. |
 
 ## How it works, briefly
 
@@ -130,7 +130,7 @@ open https://walgit.localhost:8080/
 * `Containerfile`, `flake.nix` — an OCI image and a Nix package/devshell.
 * `deploy/nginx.conf.example` — an optional nginx in front: public TLS, one `auth_request` per credential, and
   **byte offload**: walgit answers bundle/LFS downloads with `X-Accel-Redirect` and nginx streams + caches the
-  object from the bucket itself (S3 presigned or GCS with walgit's bearer). The file documents the contract.
+  object from the bucket itself (S3/Azure presigned URL or GCS bearer). The file documents the contract.
 
 Roles (`server.roles`): `serve` (git, API, UI, bundles, LFS), `maintain` (checkpoints, bundles, compaction,
 fsck/repair), `events` (the webhook bridge). Empty = all. Any number of `serve` hosts may point at one bucket; give
@@ -159,6 +159,7 @@ just clippy        # the [workspace.lints] set across all targets, warnings are 
 just ci            # warnings, clippy, test, e2e: everything that must be green before a merge
 cargo test -p walgit-server --test sim     # fault-injection simulation (crashes, partitions, stale reads)
 just test-s3       # store contract against local rustfs
+just test-azure    # store contract against local Azurite
 ```
 
 Code map:
@@ -166,7 +167,7 @@ Code map:
 ```
 crates/
   walgit-proto    protobuf schema (wal.proto), log framing, store keys
-  walgit-store    ObjectStore trait (CAS versions, conditional GET, range, compose); backends s3, gcs, memory; leases
+  walgit-store    ObjectStore trait (CAS versions, conditional GET, range, compose); backends s3, gcs, azure, memory; leases
   walgit-git      bare repos on disk, receive-pack, pack ingest, refs ↔ packed-refs, advertisements, upload-pack drivers
   walgit-wal      RepoHandle: sync levels, publish (group commit + CAS), checkpoints, log reader, remote reader, tasks
   walgit-bundle   bundle-uri: slots and chains, building, header ∘ pack composition, lists, retention

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,4 +1,4 @@
-# compose file for walgit local dev (podman compose): rustfs (S3-compatible) + bucket creation.
+# compose file for walgit local dev: rustfs (S3-compatible), Azurite, and bucket creation.
 #
 # Usage:
 #   podman compose up -d rustfs           # start rustfs
@@ -28,6 +28,14 @@ services:
       timeout: 3s
       retries: 10
 
+  azurite:
+    image: mcr.microsoft.com/azure-storage/azurite
+    command: ["azurite-blob", "--blobHost", "0.0.0.0", "--blobPort", "10000", "--skipApiVersionCheck"]
+    ports:
+      - "10000:10000"
+    volumes:
+      - azurite-data:/data
+
   # One-shot: create the walgit-test bucket after rustfs is healthy.
   create-bucket:
     image: amazon/aws-cli:latest
@@ -48,3 +56,4 @@ services:
 
 volumes:
   rustfs-data:
+  azurite-data:

--- a/crates/walgit-cli/Cargo.toml
+++ b/crates/walgit-cli/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/bin/walgit-server.rs"
 
 [dependencies]
 walgit-proto.workspace = true
-walgit-store.workspace = true
+walgit-store = { workspace = true, features = ["azure"] }
 walgit-config.workspace = true
 walgit-git.workspace = true
 walgit-wal.workspace = true

--- a/crates/walgit-config/src/lib.rs
+++ b/crates/walgit-config/src/lib.rs
@@ -231,6 +231,7 @@ pub struct StoreConfig {
     pub prefix: String,
     pub gcs: GcsConfig,
     pub s3: S3Config,
+    pub azure: AzureConfig,
     pub max_retries: u32,
     /// Objects larger than this use resumable/multipart upload.
     pub multipart_threshold: ByteSize,
@@ -243,6 +244,8 @@ pub enum StoreBackend {
     #[default]
     Gcs,
     S3,
+    /// Azure Blob Storage.
+    Azure,
     /// Tests only.
     Memory,
 }
@@ -281,6 +284,28 @@ pub struct S3Config {
     pub access_key_env: String,
     pub secret_key_env: String,
     pub force_path_style: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum AzureCredential {
+    /// Microsoft Entra Workload Identity on Kubernetes.
+    #[default]
+    WorkloadIdentity,
+    /// Storage account key read from `account_key_env`.
+    AccountKey,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct AzureConfig {
+    /// Blob endpoint. Empty uses `https://{account}.blob.core.windows.net`.
+    pub endpoint: String,
+    /// Storage account name.
+    pub account: String,
+    pub credential: AzureCredential,
+    /// Environment variable holding the account key.
+    pub account_key_env: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1075,6 +1100,7 @@ impl Default for StoreConfig {
             prefix: String::new(),
             gcs: GcsConfig::default(),
             s3: S3Config::default(),
+            azure: AzureConfig::default(),
             max_retries: 8,
             multipart_threshold: ByteSize::mib(64),
             multipart_part_size: ByteSize::mib(32),
@@ -1100,6 +1126,16 @@ impl Default for S3Config {
             access_key_env: "AWS_ACCESS_KEY_ID".into(),
             secret_key_env: "AWS_SECRET_ACCESS_KEY".into(),
             force_path_style: true,
+        }
+    }
+}
+impl Default for AzureConfig {
+    fn default() -> Self {
+        AzureConfig {
+            endpoint: String::new(),
+            account: String::new(),
+            credential: AzureCredential::WorkloadIdentity,
+            account_key_env: "AZURE_STORAGE_ACCOUNT_KEY".into(),
         }
     }
 }
@@ -1380,6 +1416,37 @@ impl Config {
     }
 
     pub fn validate(&self) -> Result<()> {
+        if self.store.backend == StoreBackend::Azure {
+            let azure = &self.store.azure;
+            anyhow::ensure!(
+                !azure.account.is_empty(),
+                "store.azure.account must be set for the azure backend"
+            );
+            anyhow::ensure!(
+                azure.endpoint.is_empty()
+                    || azure.endpoint.starts_with("https://")
+                    || azure.endpoint.starts_with("http://"),
+                "store.azure.endpoint must be an http(s) origin"
+            );
+            match azure.credential {
+                AzureCredential::WorkloadIdentity => anyhow::ensure!(
+                    azure.endpoint.is_empty() || azure.endpoint.starts_with("https://"),
+                    "store.azure.endpoint must use https for workload_identity credentials"
+                ),
+                AzureCredential::AccountKey => {
+                    anyhow::ensure!(
+                        !azure.account_key_env.is_empty(),
+                        "store.azure.account_key_env must be set for account_key credentials"
+                    );
+                    if azure.endpoint.starts_with("http://") {
+                        anyhow::ensure!(
+                            origin_is_loopback(&azure.endpoint),
+                            "store.azure.endpoint may use http only for a loopback account_key endpoint"
+                        );
+                    }
+                }
+            }
+        }
         anyhow::ensure!(!self.store.bucket.is_empty(), "store.bucket must be set");
         let t = &self.server.tls;
         match t.mode {
@@ -1992,6 +2059,85 @@ webhook_secret = "s"
         assert_eq!(c.events.webhook_secret.as_deref(), Some("s"));
         let err = Config::parse("[events]\nwebhook_url = \"ftp://x\"\n").unwrap_err();
         assert!(err.to_string().contains("webhook_url"), "{err}");
+    }
+
+    #[test]
+    fn azure_backend_parses_explicit_credentials() {
+        let c = Config::parse(
+            r#"
+[store]
+backend = "azure"
+bucket = "walgit-test"
+
+[store.azure]
+endpoint = "http://127.0.0.1:10000"
+account = "devstoreaccount1"
+credential = "account_key"
+account_key_env = "AZURE_STORAGE_ACCOUNT_KEY"
+"#,
+        )
+        .unwrap();
+        assert_eq!(c.store.backend, StoreBackend::Azure);
+        assert_eq!(c.store.azure.credential, AzureCredential::AccountKey);
+        assert_eq!(c.store.azure.account, "devstoreaccount1");
+    }
+
+    #[test]
+    fn azure_backend_defaults_to_workload_identity() {
+        let c = Config::parse(
+            "[store]\nbackend = \"azure\"\nbucket = \"b\"\n[store.azure]\naccount = \"account\"\n",
+        )
+        .unwrap();
+        assert_eq!(c.store.azure.credential, AzureCredential::WorkloadIdentity);
+    }
+
+    #[test]
+    fn azure_workload_identity_requires_https() {
+        let err = Config::parse(
+            "[store]\nbackend = \"azure\"\nbucket = \"b\"\n[store.azure]\naccount = \"a\"\nendpoint = \"http://127.0.0.1:10000\"\n",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(
+            err.contains("https") && err.contains("workload_identity"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn azure_account_key_http_requires_loopback() {
+        let err = Config::parse(
+            "[store]\nbackend = \"azure\"\nbucket = \"b\"\n[store.azure]\naccount = \"a\"\ncredential = \"account_key\"\nendpoint = \"http://blob.example.com\"\n",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(
+            err.contains("loopback") && err.contains("account_key"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn azure_backend_requires_an_account() {
+        let err = Config::parse("[store]\nbackend = \"azure\"\nbucket = \"b\"\n")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("store.azure.account"), "{err}");
+    }
+
+    #[test]
+    fn azure_section_denies_unknown_fields() {
+        let err = format!(
+            "{:#}",
+            Config::parse(
+                "[store]\nbackend = \"azure\"\nbucket = \"b\"\n[store.azure]\naccount = \"a\"\nuse_aad = true\n",
+            )
+            .unwrap_err()
+        );
+        assert!(
+            err.contains("unknown field") && err.contains("use_aad"),
+            "{err}"
+        );
     }
 
     #[test]

--- a/crates/walgit-store/Cargo.toml
+++ b/crates/walgit-store/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 default = ["gcs", "s3"]
 gcs = ["dep:google-cloud-storage", "dep:google-cloud-gax", "dep:google-cloud-auth", "dep:reqwest"]
 s3 = ["dep:aws-config", "dep:aws-sdk-s3", "dep:aws-smithy-types", "dep:reqwest"]
+azure = ["dep:reqwest", "dep:hmac", "dep:sha2", "dep:base64", "dep:chrono", "dep:azure_core", "dep:azure_identity"]
 
 [dependencies]
 walgit-proto.workspace = true
@@ -36,6 +37,12 @@ aws-config = { workspace = true, optional = true }
 aws-sdk-s3 = { workspace = true, optional = true }
 aws-smithy-types = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
+hmac = { workspace = true, optional = true }
+sha2 = { workspace = true, optional = true }
+base64 = { workspace = true, optional = true }
+chrono = { workspace = true, optional = true }
+azure_core = { workspace = true, optional = true }
+azure_identity = { workspace = true, optional = true }
 [dev-dependencies]
 axum.workspace = true
 tempfile.workspace = true

--- a/crates/walgit-store/src/azure.rs
+++ b/crates/walgit-store/src/azure.rs
@@ -1,0 +1,1330 @@
+//! Azure Blob Storage backend.
+//!
+//! Speaks the Blob REST API over `reqwest` with Shared Key (HMAC-SHA256) or
+//! AKS Workload Identity. The REST API keeps account-key/Azurite support and
+//! permits service and user-delegation SAS signing without a second client.
+//!
+//! ## Version tokens
+//!
+//! Blob ETags are opaque `Version` strings. Quotes are stripped on read and
+//! re-applied on `If-Match` / `If-None-Match`. Callers never parse them.
+//!
+//! ## Conditional PUT
+//!
+//! `PutMode::Create`    → `If-None-Match: *`
+//! `PutMode::Update(v)` → `If-Match: "<etag>"`
+//! Both 412 and 409 (BlobAlreadyExists) map to `PreconditionFailed`.
+//!
+//! ## Compose
+//!
+//! Put Block From URL (server-side copy of each source, authenticated with a
+//! short SAS) + Put Block List. Azurite copies bounded ranges through this
+//! process because it does not implement Put Block From URL. `compose_is_native`
+//! is false: bytes still move inside the account.
+//!
+//! ## URL shape
+//!
+//! Production (`{account}.blob.*`): `https://{account}.blob.core.windows.net/{container}/{key}`.
+//! Azurite / custom endpoint: `{endpoint}/{account}/{container}/{key}`.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use base64::Engine as _;
+use bytes::Bytes;
+use chrono::{DateTime, SecondsFormat, Utc};
+use futures::StreamExt;
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+
+use crate::{
+    BoxStream, GetOptions, GetResult, ObjectMeta, ObjectStore, PutBody, PutMode, PutOptions,
+    Result, StoreError, Version, util,
+};
+
+const API_VERSION: &str = "2021-12-02";
+const IMMUTABLE_CACHE_CONTROL: &str = "public, max-age=31536000, immutable";
+
+type HmacSha256 = Hmac<Sha256>;
+
+#[derive(Clone)]
+enum AzureAuth {
+    SharedKey {
+        key: Vec<u8>,
+    },
+    WorkloadIdentity {
+        credential: Arc<azure_identity::WorkloadIdentityCredential>,
+        delegation_key: Arc<tokio::sync::Mutex<Option<UserDelegation>>>,
+    },
+}
+
+/// Azure Blob object store.
+#[derive(Clone)]
+pub struct AzureStore {
+    /// Control-plane client for metadata objects and operations.
+    http: reqwest::Client,
+    /// Bulk-key and ranged GET/PUT client — its own pool keeps multi-GB
+    /// transfers from stalling manifest traffic (D19).
+    bulk: reqwest::Client,
+    account: String,
+    /// Origin + account-path prefix, no trailing slash.
+    /// Production: `https://acct.blob.core.windows.net`
+    /// Azurite: `http://127.0.0.1:10000/devstoreaccount1`
+    service_url: String,
+    container: String,
+    auth: AzureAuth,
+    path_style: bool,
+    multipart_threshold: u64,
+    multipart_part_size: u64,
+}
+
+impl AzureStore {
+    /// Build a store from `walgit-config::StoreConfig`.
+    ///
+    /// The selected credential mode is exclusive. Missing configuration or
+    /// credentials fail before the store can serve requests.
+    pub async fn new(cfg: &walgit_config::StoreConfig) -> anyhow::Result<Self> {
+        let parsed = resolve_azure(cfg)?;
+        let http = reqwest::Client::builder()
+            .pool_max_idle_per_host(8)
+            .timeout(Duration::from_secs(60))
+            .build()?;
+        let bulk = reqwest::Client::builder()
+            .pool_max_idle_per_host(32)
+            .timeout(Duration::from_secs(3600))
+            .build()?;
+        Ok(AzureStore {
+            http,
+            bulk,
+            account: parsed.account,
+            service_url: parsed.service_url,
+            container: cfg.bucket.clone(),
+            path_style: parsed.path_style,
+            auth: parsed.auth,
+            multipart_threshold: cfg.multipart_threshold.as_u64(),
+            multipart_part_size: cfg.multipart_part_size.as_u64().max(1),
+        })
+    }
+
+    /// Create the container if it does not exist (409 = already there).
+    pub async fn ensure_container(&self) -> Result<()> {
+        let url = format!("{}?restype=container", self.container_url());
+        let resp = self
+            .execute(
+                self.http
+                    .put(&url)
+                    .header("content-length", "0")
+                    .body(Bytes::new()),
+                false,
+            )
+            .await?;
+        match resp.status().as_u16() {
+            201 | 202 | 409 => Ok(()),
+            s => {
+                let body = resp.text().await.unwrap_or_default();
+                Err(StoreError::other(anyhow::anyhow!(
+                    "azure create container {s}: {body}"
+                )))
+            }
+        }
+    }
+
+    fn container_url(&self) -> String {
+        format!("{}/{}", self.service_url, self.container)
+    }
+
+    fn object_url(&self, key: &str) -> String {
+        format!("{}/{}", self.container_url(), util::encode_path(key))
+    }
+
+    fn client(&self, bulk: bool) -> &reqwest::Client {
+        if bulk { &self.bulk } else { &self.http }
+    }
+
+    async fn execute(
+        &self,
+        builder: reqwest::RequestBuilder,
+        bulk: bool,
+    ) -> Result<reqwest::Response> {
+        let mut req = builder
+            .build()
+            .map_err(|e| StoreError::other(anyhow::anyhow!("azure build request: {e}")))?;
+        req.headers_mut().insert(
+            "x-ms-version",
+            API_VERSION.parse().expect("api version is ascii"),
+        );
+        if !req.headers().contains_key("x-ms-date") {
+            let date = Utc::now().format("%a, %d %b %Y %H:%M:%S GMT").to_string();
+            req.headers_mut().insert(
+                "x-ms-date",
+                date.parse()
+                    .map_err(|e| StoreError::other(anyhow::anyhow!("azure date header: {e}")))?,
+            );
+        }
+        match &self.auth {
+            AzureAuth::SharedKey { key } => {
+                let auth =
+                    shared_key_auth(&self.account, key, req.method(), req.url(), req.headers())?;
+                req.headers_mut().insert(
+                    reqwest::header::AUTHORIZATION,
+                    auth.parse().map_err(|e| {
+                        StoreError::other(anyhow::anyhow!("azure auth header: {e}"))
+                    })?,
+                );
+            }
+            AzureAuth::WorkloadIdentity { credential, .. } => {
+                let token = Self::bearer_token(credential).await?;
+                req.headers_mut().insert(
+                    reqwest::header::AUTHORIZATION,
+                    format!("Bearer {token}").parse().map_err(|e| {
+                        StoreError::other(anyhow::anyhow!("azure bearer header: {e}"))
+                    })?,
+                );
+            }
+        }
+        self.client(bulk)
+            .execute(req)
+            .await
+            .map_err(|e| StoreError::retryable(anyhow::anyhow!("azure http: {e}")))
+    }
+
+    async fn bearer_token(
+        credential: &azure_identity::WorkloadIdentityCredential,
+    ) -> Result<String> {
+        use azure_core::credentials::TokenCredential;
+        let token = credential
+            .get_token(&["https://storage.azure.com/.default"], None)
+            .await
+            .map_err(|e| {
+                StoreError::other(anyhow::anyhow!("azure workload identity token: {e}"))
+            })?;
+        Ok(token.token.secret().to_owned())
+    }
+
+    fn range_header(range: &std::ops::Range<u64>) -> String {
+        format!("bytes={}-{}", range.start, range.end.saturating_sub(1))
+    }
+
+    fn quote_etag(v: &str) -> String {
+        if v == "*" || (v.starts_with('"') && v.ends_with('"')) {
+            v.to_owned()
+        } else {
+            format!("\"{v}\"")
+        }
+    }
+
+    fn apply_put_conditions(b: reqwest::RequestBuilder, mode: &PutMode) -> reqwest::RequestBuilder {
+        match mode {
+            PutMode::Overwrite => b,
+            PutMode::Create => b.header("if-none-match", "*"),
+            PutMode::Update(v) => b.header("if-match", Self::quote_etag(v.as_str())),
+        }
+    }
+
+    fn get_result_from_response(key: &str, resp: reqwest::Response) -> Result<GetResult> {
+        let status = resp.status().as_u16();
+        let etag = header_str(resp.headers(), "etag").map(|s| strip_etag(&s));
+        let content_length =
+            header_str(resp.headers(), "content-length").and_then(|s| s.parse::<u64>().ok());
+        let total = header_str(resp.headers(), "content-range").and_then(|v| {
+            v.rsplit_once('/')
+                .and_then(|(_, t)| t.trim().parse::<u64>().ok())
+        });
+        match status {
+            200 | 206 => {
+                let meta = ObjectMeta {
+                    key: key.into(),
+                    size: total.or(content_length).unwrap_or(0),
+                    version: Version::new(etag.as_deref().unwrap_or("")),
+                };
+                let body = resp
+                    .bytes_stream()
+                    .map(|r| {
+                        r.map_err(|e| StoreError::retryable(anyhow::anyhow!("azure body: {e}")))
+                    })
+                    .boxed();
+                Ok(GetResult::Object { meta, body })
+            }
+            304 => Ok(GetResult::NotModified {
+                version: Version::new(etag.as_deref().unwrap_or("")),
+            }),
+            404 => Err(StoreError::NotFound { key: key.into() }),
+            412 | 409 => Err(StoreError::PreconditionFailed {
+                key: key.into(),
+                current: etag.map(Version::new),
+            }),
+            s if s >= 500 || s == 429 => Err(StoreError::Retryable(anyhow::anyhow!(
+                "azure get status {s}"
+            ))),
+            s => Err(StoreError::Other(anyhow::anyhow!("azure get status {s}"))),
+        }
+    }
+
+    fn classify_write(key: &str, status: u16, etag: Option<String>, body: &str) -> StoreError {
+        match status {
+            404 => StoreError::NotFound { key: key.into() },
+            412 | 409 => StoreError::PreconditionFailed {
+                key: key.into(),
+                current: etag.map(Version::new),
+            },
+            s if s >= 500 || s == 429 => {
+                StoreError::Retryable(anyhow::anyhow!("azure status {s}: {body}"))
+            }
+            s => StoreError::Other(anyhow::anyhow!("azure status {s}: {body}")),
+        }
+    }
+
+    async fn put_blob(&self, key: &str, body: Bytes, opts: &PutOptions) -> Result<ObjectMeta> {
+        let len = body.len() as u64;
+        let url = self.object_url(key);
+        let bulk = util::is_bulk_key(key);
+        let mut builder = self
+            .client(bulk)
+            .put(&url)
+            .header("x-ms-blob-type", "BlockBlob")
+            .header("content-length", len.to_string())
+            .body(body);
+        builder = Self::apply_put_conditions(builder, &opts.mode);
+        if let Some(content_type) = opts.content_type {
+            builder = builder.header("x-ms-blob-content-type", content_type);
+        }
+        if opts.immutable {
+            builder = builder.header("x-ms-blob-cache-control", IMMUTABLE_CACHE_CONTROL);
+        }
+        let resp = self.execute(builder, bulk).await?;
+        let status = resp.status().as_u16();
+        let etag = header_str(resp.headers(), "etag").map(|s| strip_etag(&s));
+        if (200..300).contains(&status) {
+            return Ok(ObjectMeta {
+                key: key.into(),
+                size: len,
+                version: Version::new(etag.as_deref().unwrap_or("")),
+            });
+        }
+        let body = resp.text().await.unwrap_or_default();
+        let mut err = Self::classify_write(key, status, etag, &body);
+        if let StoreError::PreconditionFailed { current: c, .. } = &mut err
+            && c.is_none()
+        {
+            *c = self.head(key).await.ok().flatten().map(|m| m.version);
+        }
+        Err(err)
+    }
+
+    fn block_id(upload: &str, n: u32) -> String {
+        base64::engine::general_purpose::STANDARD.encode(format!("{upload}:{n:016}"))
+    }
+
+    fn upload_id() -> String {
+        uuid::Uuid::new_v4().simple().to_string()
+    }
+
+    async fn put_block(&self, key: &str, upload: &str, n: u32, data: Bytes) -> Result<()> {
+        let id = Self::block_id(upload, n);
+        let url = format!(
+            "{}?comp=block&blockid={}",
+            self.object_url(key),
+            query_encode(&id)
+        );
+        let len = data.len();
+        let builder = self
+            .bulk
+            .put(&url)
+            .header("content-length", len.to_string())
+            .header("x-ms-blob-type", "BlockBlob")
+            .body(data);
+        let resp = self.execute(builder, true).await?;
+        let status = resp.status().as_u16();
+        if (200..300).contains(&status) {
+            return Ok(());
+        }
+        let body = resp.text().await.unwrap_or_default();
+        Err(Self::classify_write(key, status, None, &body))
+    }
+
+    async fn put_block_from_url(
+        &self,
+        dest: &str,
+        upload: &str,
+        n: u32,
+        source_url: &str,
+        range: std::ops::Range<u64>,
+    ) -> Result<()> {
+        let id = Self::block_id(upload, n);
+        let url = format!(
+            "{}?comp=block&blockid={}",
+            self.object_url(dest),
+            query_encode(&id)
+        );
+        let src_range = format!("bytes={}-{}", range.start, range.end.saturating_sub(1));
+        let b = self
+            .bulk
+            .put(&url)
+            .header("content-length", "0")
+            .header("x-ms-copy-source", source_url)
+            .header("x-ms-source-range", src_range)
+            .body(Bytes::new());
+        let resp = self.execute(b, true).await?;
+        let status = resp.status().as_u16();
+        if (200..300).contains(&status) {
+            return Ok(());
+        }
+        let body = resp.text().await.unwrap_or_default();
+        Err(Self::classify_write(dest, status, None, &body))
+    }
+
+    async fn commit_block_list(
+        &self,
+        key: &str,
+        upload: &str,
+        n_blocks: u32,
+        opts: &PutOptions,
+        size: u64,
+    ) -> Result<ObjectMeta> {
+        let mut xml = String::from("<?xml version=\"1.0\" encoding=\"utf-8\"?><BlockList>");
+        for i in 0..n_blocks {
+            xml.push_str("<Latest>");
+            xml.push_str(&Self::block_id(upload, i));
+            xml.push_str("</Latest>");
+        }
+        xml.push_str("</BlockList>");
+        let url = format!("{}?comp=blocklist", self.object_url(key));
+        let bulk = util::is_bulk_key(key);
+        let mut builder = self
+            .client(bulk)
+            .put(&url)
+            .header("content-type", "application/xml")
+            .header("content-length", xml.len().to_string())
+            .body(xml);
+        builder = Self::apply_put_conditions(builder, &opts.mode);
+        if let Some(content_type) = opts.content_type {
+            builder = builder.header("x-ms-blob-content-type", content_type);
+        }
+        if opts.immutable {
+            builder = builder.header("x-ms-blob-cache-control", IMMUTABLE_CACHE_CONTROL);
+        }
+        let resp = self.execute(builder, bulk).await?;
+        let status = resp.status().as_u16();
+        let etag = header_str(resp.headers(), "etag").map(|s| strip_etag(&s));
+        if (200..300).contains(&status) {
+            return Ok(ObjectMeta {
+                key: key.into(),
+                size,
+                version: Version::new(etag.as_deref().unwrap_or("")),
+            });
+        }
+        let body = resp.text().await.unwrap_or_default();
+        let mut err = Self::classify_write(key, status, etag, &body);
+        if let StoreError::PreconditionFailed { current: c, .. } = &mut err
+            && c.is_none()
+        {
+            *c = self.head(key).await.ok().flatten().map(|m| m.version);
+        }
+        Err(err)
+    }
+
+    async fn put_blocks_bytes(
+        &self,
+        key: &str,
+        data: Bytes,
+        opts: &PutOptions,
+    ) -> Result<ObjectMeta> {
+        let size = data.len() as u64;
+        let part = self.multipart_part_size as usize;
+        let upload = Self::upload_id();
+        let mut n = 0u32;
+        let mut offset = 0usize;
+        while offset < data.len() {
+            let end = (offset + part).min(data.len());
+            self.put_block(key, &upload, n, data.slice(offset..end))
+                .await?;
+            n += 1;
+            offset = end;
+        }
+        if n == 0 {
+            self.put_block(key, &upload, 0, Bytes::new()).await?;
+            n = 1;
+        }
+        self.commit_block_list(key, &upload, n, opts, size).await
+    }
+
+    async fn put_stream(
+        &self,
+        key: &str,
+        mut stream: crate::ByteStream,
+        len: u64,
+        opts: &PutOptions,
+    ) -> Result<ObjectMeta> {
+        let part = self.multipart_part_size as usize;
+        let upload = Self::upload_id();
+        let mut buf = bytes::BytesMut::new();
+        let mut n = 0u32;
+        while let Some(chunk) = stream.next().await {
+            buf.extend_from_slice(&chunk?);
+            while buf.len() >= part {
+                let block = buf.split_to(part).freeze();
+                self.put_block(key, &upload, n, block).await?;
+                n += 1;
+            }
+        }
+        if !buf.is_empty() || n == 0 {
+            self.put_block(key, &upload, n, buf.freeze()).await?;
+            n += 1;
+        }
+        self.commit_block_list(key, &upload, n, opts, len).await
+    }
+
+    async fn list_page(
+        &self,
+        prefix: &str,
+        marker: Option<&str>,
+        delimiter: Option<&str>,
+        max_results: u32,
+    ) -> Result<ListPage> {
+        let mut url = format!("{}?restype=container&comp=list", self.container_url());
+        if !prefix.is_empty() {
+            url.push_str("&prefix=");
+            url.push_str(&query_encode(prefix));
+        }
+        if let Some(m) = marker.filter(|s| !s.is_empty()) {
+            url.push_str("&marker=");
+            url.push_str(&query_encode(m));
+        }
+        if let Some(d) = delimiter {
+            url.push_str("&delimiter=");
+            url.push_str(&query_encode(d));
+        }
+        url.push_str("&maxresults=");
+        url.push_str(&max_results.to_string());
+        let resp = self.execute(self.http.get(&url), false).await?;
+        let status = resp.status().as_u16();
+        if !(200..300).contains(&status) {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(Self::classify_write(prefix, status, None, &body));
+        }
+        let body = resp
+            .text()
+            .await
+            .map_err(|e| StoreError::other(anyhow::anyhow!("azure list body: {e}")))?;
+        Ok(parse_list_xml(&body))
+    }
+
+    /// Service SAS (account key) or user-delegation SAS (Entra).
+    async fn mint_sas(&self, key: &str, ttl: Duration) -> Result<String> {
+        let start = Utc::now() - chrono::Duration::minutes(5);
+        let expiry =
+            Utc::now() + chrono::Duration::from_std(ttl).unwrap_or(chrono::Duration::hours(1));
+        let st = start.to_rfc3339_opts(SecondsFormat::Secs, true);
+        let se = expiry.to_rfc3339_opts(SecondsFormat::Secs, true);
+        let resource = format!("/blob/{}/{}/{}", self.account, self.container, key);
+        match &self.auth {
+            AzureAuth::SharedKey { key: account_key } => {
+                // sp + st + se + canonicalizedResource + ident + ip + proto + sv + sr + snapshot
+                // + enc + rscc + rscd + rsce + rscl + rsct  (2020-12-06+)
+                let string_to_sign =
+                    format!("r\n{st}\n{se}\n{resource}\n\n\n\n{API_VERSION}\nb\n\n\n\n\n\n\n");
+                let sig = hmac_b64(account_key, &string_to_sign);
+                Ok(format!(
+                    "{}?sp=r&st={}&se={}&sv={}&sr=b&sig={}",
+                    self.object_url(key),
+                    query_encode(&st),
+                    query_encode(&se),
+                    API_VERSION,
+                    query_encode(&sig)
+                ))
+            }
+            AzureAuth::WorkloadIdentity { .. } => {
+                let udef = self.user_delegation_key(expiry).await?;
+                let string_to_sign = format!(
+                    "r\n{st}\n{se}\n{resource}\n{}\n{}\n{}\n{}\n{}\n{}\n\n\n\n\n{API_VERSION}\nb\n\n\n\n\n\n\n",
+                    udef.oid, udef.tid, udef.start, udef.expiry, udef.service, udef.version
+                );
+                let sig = hmac_b64(&udef.key, &string_to_sign);
+                Ok(format!(
+                    "{}?sp=r&st={}&se={}&sv={}&sr=b&skoid={}&sktid={}&skt={}&ske={}&sks={}&skv={}&sig={}",
+                    self.object_url(key),
+                    query_encode(&st),
+                    query_encode(&se),
+                    API_VERSION,
+                    query_encode(&udef.oid),
+                    query_encode(&udef.tid),
+                    query_encode(&udef.start),
+                    query_encode(&udef.expiry),
+                    query_encode(&udef.service),
+                    query_encode(&udef.version),
+                    query_encode(&sig),
+                ))
+            }
+        }
+    }
+
+    async fn user_delegation_key(&self, required_expiry: DateTime<Utc>) -> Result<UserDelegation> {
+        let AzureAuth::WorkloadIdentity { delegation_key, .. } = &self.auth else {
+            return Err(StoreError::other(anyhow::anyhow!(
+                "azure: user delegation key requires workload identity"
+            )));
+        };
+        let mut cache = delegation_key.lock().await;
+        let now = Utc::now();
+        if let Some(key) = cached_delegation_key(cache.as_ref(), &required_expiry, &now) {
+            return Ok(key);
+        }
+
+        let start = now - chrono::Duration::minutes(5);
+        let expiry = now + chrono::Duration::hours(167);
+        if required_expiry + chrono::Duration::minutes(5) >= expiry {
+            return Err(StoreError::InvalidArgument(
+                "azure user-delegation signed URL TTL must be less than 167 hours".into(),
+            ));
+        }
+        let start_text = start.to_rfc3339_opts(SecondsFormat::Secs, true);
+        let expiry_text = expiry.to_rfc3339_opts(SecondsFormat::Secs, true);
+        let url = format!(
+            "{}?restype=service&comp=userdelegationkey",
+            self.service_url
+        );
+        let body = format!(
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?><KeyInfo><Start>{start_text}</Start><Expiry>{expiry_text}</Expiry></KeyInfo>"
+        );
+        let response = self
+            .execute(
+                self.http
+                    .post(&url)
+                    .header("content-type", "application/xml")
+                    .header("content-length", body.len().to_string())
+                    .body(body),
+                false,
+            )
+            .await?;
+        let status = response.status().as_u16();
+        let text = response.text().await.unwrap_or_default();
+        if !(200..300).contains(&status) {
+            return Err(StoreError::other(anyhow::anyhow!(
+                "azure user delegation key {status}: {text}"
+            )));
+        }
+        let value = xml_text(&text, "Value").ok_or_else(|| {
+            StoreError::other(anyhow::anyhow!("azure user delegation key: no Value"))
+        })?;
+        let key = base64::engine::general_purpose::STANDARD
+            .decode(value.trim())
+            .map_err(|e| StoreError::other(anyhow::anyhow!("azure delegation key: {e}")))?;
+        let signed_expiry = xml_text(&text, "SignedExpiry").unwrap_or(&expiry_text);
+        let expires_at = DateTime::parse_from_rfc3339(signed_expiry)
+            .map(|value| value.with_timezone(&Utc))
+            .map_err(|e| StoreError::other(anyhow::anyhow!("azure delegation expiry: {e}")))?;
+        let delegation = UserDelegation {
+            oid: xml_text(&text, "SignedOid").unwrap_or_default().to_owned(),
+            tid: xml_text(&text, "SignedTid").unwrap_or_default().to_owned(),
+            start: xml_text(&text, "SignedStart")
+                .unwrap_or(&start_text)
+                .to_owned(),
+            expiry: signed_expiry.to_owned(),
+            expires_at,
+            service: xml_text(&text, "SignedService").unwrap_or("b").to_owned(),
+            version: xml_text(&text, "SignedVersion")
+                .unwrap_or(API_VERSION)
+                .to_owned(),
+            key,
+        };
+        *cache = Some(delegation.clone());
+        Ok(delegation)
+    }
+}
+
+fn cached_delegation_key(
+    cached: Option<&UserDelegation>,
+    required_expiry: &DateTime<Utc>,
+    now: &DateTime<Utc>,
+) -> Option<UserDelegation> {
+    cached
+        .filter(|key| delegation_key_is_fresh(&key.expires_at, required_expiry, now))
+        .cloned()
+}
+
+fn delegation_key_is_fresh(
+    expires_at: &DateTime<Utc>,
+    required_expiry: &DateTime<Utc>,
+    now: &DateTime<Utc>,
+) -> bool {
+    let margin = chrono::Duration::minutes(5);
+    expires_at.signed_duration_since(required_expiry.to_owned()) > margin
+        && expires_at.signed_duration_since(now.to_owned()) > margin
+}
+
+#[derive(Clone)]
+struct UserDelegation {
+    oid: String,
+    tid: String,
+    start: String,
+    expiry: String,
+    expires_at: DateTime<Utc>,
+    service: String,
+    version: String,
+    key: Vec<u8>,
+}
+
+struct ParsedAzure {
+    account: String,
+    service_url: String,
+    path_style: bool,
+    auth: AzureAuth,
+}
+
+fn resolve_azure(cfg: &walgit_config::StoreConfig) -> anyhow::Result<ParsedAzure> {
+    let azure = &cfg.azure;
+    if azure.account.is_empty() {
+        anyhow::bail!("azure: store.azure.account must be set");
+    }
+    let auth = match azure.credential {
+        walgit_config::AzureCredential::AccountKey => {
+            let encoded = std::env::var(&azure.account_key_env).map_err(|_| {
+                anyhow::anyhow!(
+                    "azure: account_key credential requires env {}",
+                    azure.account_key_env
+                )
+            })?;
+            let key = base64::engine::general_purpose::STANDARD
+                .decode(encoded.trim())
+                .map_err(|e| anyhow::anyhow!("azure: account key is not valid base64: {e}"))?;
+            AzureAuth::SharedKey { key }
+        }
+        walgit_config::AzureCredential::WorkloadIdentity => {
+            let credential = azure_identity::WorkloadIdentityCredential::new(None)
+                .map_err(|e| anyhow::anyhow!("azure workload identity credential: {e}"))?;
+            AzureAuth::WorkloadIdentity {
+                credential,
+                delegation_key: Arc::new(tokio::sync::Mutex::new(None)),
+            }
+        }
+    };
+    let (service_url, path_style) = service_url_for(&azure.account, &azure.endpoint);
+    Ok(ParsedAzure {
+        account: azure.account.clone(),
+        service_url,
+        path_style,
+        auth,
+    })
+}
+
+fn service_url_for(account: &str, endpoint: &str) -> (String, bool) {
+    if endpoint.is_empty() {
+        return (format!("https://{account}.blob.core.windows.net"), false);
+    }
+    let endpoint = endpoint.trim_end_matches('/');
+    let Ok(u) = reqwest::Url::parse(endpoint) else {
+        return (endpoint.to_owned(), true);
+    };
+    let host = u.host_str().unwrap_or("");
+    let path_style = !host.eq_ignore_ascii_case(&format!("{account}.blob.core.windows.net"))
+        && !host
+            .to_ascii_lowercase()
+            .starts_with(&format!("{}.blob.", account.to_ascii_lowercase()));
+    if path_style {
+        let origin = format!(
+            "{}://{}{}",
+            u.scheme(),
+            host,
+            u.port().map(|p| format!(":{p}")).unwrap_or_default()
+        );
+        (format!("{origin}/{account}"), true)
+    } else {
+        let origin = format!(
+            "{}://{}{}",
+            u.scheme(),
+            host,
+            u.port().map(|p| format!(":{p}")).unwrap_or_default()
+        );
+        (origin, false)
+    }
+}
+
+fn shared_key_auth(
+    account: &str,
+    key: &[u8],
+    method: &reqwest::Method,
+    url: &reqwest::Url,
+    headers: &reqwest::header::HeaderMap,
+) -> Result<String> {
+    let sts = string_to_sign(account, method, url, headers);
+    let sig = hmac_b64(key, &sts);
+    Ok(format!("SharedKey {account}:{sig}"))
+}
+
+fn string_to_sign(
+    account: &str,
+    method: &reqwest::Method,
+    url: &reqwest::Url,
+    headers: &reqwest::header::HeaderMap,
+) -> String {
+    let content_length = header_str(headers, "content-length")
+        .filter(|v| v != "0")
+        .unwrap_or_default();
+    format!(
+        "{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}{}",
+        method.as_str(),
+        header_str(headers, "content-encoding").unwrap_or_default(),
+        header_str(headers, "content-language").unwrap_or_default(),
+        content_length,
+        header_str(headers, "content-md5").unwrap_or_default(),
+        header_str(headers, "content-type").unwrap_or_default(),
+        header_str(headers, "date").unwrap_or_default(),
+        header_str(headers, "if-modified-since").unwrap_or_default(),
+        header_str(headers, "if-match").unwrap_or_default(),
+        header_str(headers, "if-none-match").unwrap_or_default(),
+        header_str(headers, "if-unmodified-since").unwrap_or_default(),
+        header_str(headers, "range").unwrap_or_default(),
+        canonicalize_headers(headers),
+        canonicalize_resource(account, url),
+    )
+}
+
+fn canonicalize_headers(headers: &reqwest::header::HeaderMap) -> String {
+    let mut ms: Vec<(String, String)> = headers
+        .iter()
+        .filter_map(|(k, v)| {
+            let name = k.as_str().to_ascii_lowercase();
+            if !name.starts_with("x-ms-") {
+                return None;
+            }
+            let val = v.to_str().ok()?.trim().to_owned();
+            Some((name, val))
+        })
+        .collect();
+    ms.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut out = String::new();
+    for (n, v) in ms {
+        out.push_str(&n);
+        out.push(':');
+        out.push_str(&v);
+        out.push('\n');
+    }
+    out
+}
+
+fn canonicalize_resource(account: &str, url: &reqwest::Url) -> String {
+    let mut can = String::new();
+    can.push('/');
+    can.push_str(account);
+    can.push_str(url.path());
+    let mut params: Vec<(String, String)> = url
+        .query_pairs()
+        .map(|(k, v)| (k.to_ascii_lowercase(), v.into_owned()))
+        .collect();
+    params.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
+    for (n, v) in params {
+        can.push('\n');
+        can.push_str(&n);
+        can.push(':');
+        can.push_str(&v);
+    }
+    can
+}
+
+fn hmac_b64(key: &[u8], data: &str) -> String {
+    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC-SHA256 accepts any key length");
+    mac.update(data.as_bytes());
+    base64::engine::general_purpose::STANDARD.encode(mac.finalize().into_bytes())
+}
+
+fn header_str(h: &reqwest::header::HeaderMap, name: &str) -> Option<String> {
+    h.get(name)?.to_str().ok().map(|s| s.to_owned())
+}
+
+fn strip_etag(v: &str) -> String {
+    v.trim()
+        .replace("&quot;", "\"")
+        .trim_matches('"')
+        .to_owned()
+}
+
+fn query_encode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char)
+            }
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
+fn xml_text<'a>(s: &'a str, tag: &str) -> Option<&'a str> {
+    let open = format!("<{tag}>");
+    let open_alt = format!("<{tag} ");
+    let close = format!("</{tag}>");
+    let start = if let Some(i) = s.find(&open) {
+        i + open.len()
+    } else {
+        let i = s.find(&open_alt)?;
+        s[i..].find('>')? + i + 1
+    };
+    let end = s[start..].find(&close)? + start;
+    Some(&s[start..end])
+}
+
+struct ListPage {
+    blobs: Vec<ObjectMeta>,
+    prefixes: Vec<String>,
+    next_marker: Option<String>,
+}
+
+fn parse_list_xml(body: &str) -> ListPage {
+    let mut blobs = Vec::new();
+    let mut prefixes = Vec::new();
+    // Walk <Blob>…</Blob> (not BlobPrefix).
+    let mut rest = body;
+    while let Some(start) = rest.find("<Blob>") {
+        let after = &rest[start + 6..];
+        let Some(end) = after.find("</Blob>") else {
+            break;
+        };
+        let blob = &after[..end];
+        rest = &after[end + 7..];
+        // Skip BlobPrefix accidentally? <Blob> doesn't match BlobPrefix.
+        let Some(name) = xml_text(blob, "Name") else {
+            continue;
+        };
+        let name = xml_unescape(name);
+        let size = xml_text(blob, "Content-Length")
+            .and_then(|s| s.trim().parse::<u64>().ok())
+            .unwrap_or(0);
+        let etag = xml_text(blob, "Etag")
+            .or_else(|| xml_text(blob, "ETag"))
+            .map(strip_etag)
+            .unwrap_or_default();
+        blobs.push(ObjectMeta {
+            key: name,
+            size,
+            version: Version::new(etag),
+        });
+    }
+    rest = body;
+    while let Some(start) = rest.find("<BlobPrefix>") {
+        let after = &rest[start + 12..];
+        let Some(end) = after.find("</BlobPrefix>") else {
+            break;
+        };
+        let p = &after[..end];
+        rest = &after[end + 13..];
+        if let Some(name) = xml_text(p, "Name") {
+            prefixes.push(xml_unescape(name));
+        }
+    }
+    let next_marker = xml_text(body, "NextMarker")
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty());
+    ListPage {
+        blobs,
+        prefixes,
+        next_marker,
+    }
+}
+
+fn xml_unescape(s: &str) -> String {
+    s.replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&apos;", "'")
+}
+
+#[async_trait::async_trait]
+impl ObjectStore for AzureStore {
+    fn backend(&self) -> &'static str {
+        "azure"
+    }
+
+    async fn get(&self, key: &str, opts: GetOptions) -> Result<GetResult> {
+        let url = self.object_url(key);
+        let bulk = opts.range.is_some() || util::is_bulk_key(key);
+        let mut builder = self.client(bulk).get(&url);
+        if let Some(version) = &opts.if_none_match {
+            builder = builder.header("if-none-match", Self::quote_etag(version.as_str()));
+        }
+        if let Some(version) = &opts.if_match {
+            builder = builder.header("if-match", Self::quote_etag(version.as_str()));
+        }
+        if let Some(range) = &opts.range {
+            builder = builder.header("range", Self::range_header(range));
+        }
+        let response = self.execute(builder, bulk).await?;
+        Self::get_result_from_response(key, response)
+    }
+
+    async fn head(&self, key: &str) -> Result<Option<ObjectMeta>> {
+        let url = self.object_url(key);
+        let resp = self.execute(self.http.head(&url), false).await?;
+        let status = resp.status().as_u16();
+        match status {
+            200 => {
+                let etag = header_str(resp.headers(), "etag").map(|s| strip_etag(&s));
+                let size = header_str(resp.headers(), "content-length")
+                    .and_then(|s| s.parse::<u64>().ok())
+                    .unwrap_or(0);
+                Ok(Some(ObjectMeta {
+                    key: key.into(),
+                    size,
+                    version: Version::new(etag.as_deref().unwrap_or("")),
+                }))
+            }
+            404 => Ok(None),
+            s => {
+                let body = resp.text().await.unwrap_or_default();
+                Err(Self::classify_write(key, s, None, &body))
+            }
+        }
+    }
+
+    async fn put(&self, key: &str, body: PutBody, opts: PutOptions) -> Result<ObjectMeta> {
+        match body {
+            PutBody::Bytes(b) => {
+                if b.len() as u64 > self.multipart_threshold {
+                    self.put_blocks_bytes(key, b, &opts).await
+                } else {
+                    self.put_blob(key, b, &opts).await
+                }
+            }
+            PutBody::Stream { len, stream } => {
+                if len > self.multipart_threshold {
+                    self.put_stream(key, stream, len, &opts).await
+                } else {
+                    let collected = util::collect(stream, len as usize).await?;
+                    self.put_blob(key, collected, &opts).await
+                }
+            }
+            PutBody::File(path) => {
+                let meta = tokio::fs::metadata(&path).await.map_err(|e| {
+                    StoreError::other(anyhow::anyhow!("stat {}: {e}", path.display()))
+                })?;
+                let len = meta.len();
+                if len > self.multipart_threshold {
+                    let stream = util::file_stream(path, None, 1024 * 1024);
+                    self.put_stream(key, stream, len, &opts).await
+                } else {
+                    let data = tokio::fs::read(&path).await.map_err(|e| {
+                        StoreError::other(anyhow::anyhow!("read {}: {e}", path.display()))
+                    })?;
+                    self.put_blob(key, Bytes::from(data), &opts).await
+                }
+            }
+        }
+    }
+
+    async fn delete(&self, key: &str, if_version: Option<Version>) -> Result<()> {
+        let url = self.object_url(key);
+        let mut builder = self.http.delete(&url);
+        if let Some(version) = &if_version {
+            builder = builder.header("if-match", Self::quote_etag(version.as_str()));
+        }
+        let response = self.execute(builder, false).await?;
+        let status = response.status().as_u16();
+        match status {
+            200 | 202 => Ok(()),
+            404 if if_version.is_none() => Ok(()),
+            404 => Err(StoreError::NotFound { key: key.into() }),
+            412 | 409 => match self.head(key).await? {
+                None => Err(StoreError::NotFound { key: key.into() }),
+                Some(meta) => Err(StoreError::PreconditionFailed {
+                    key: key.into(),
+                    current: Some(meta.version),
+                }),
+            },
+            status => {
+                let body = response.text().await.unwrap_or_default();
+                Err(Self::classify_write(key, status, None, &body))
+            }
+        }
+    }
+
+    fn list(
+        &self,
+        prefix: &str,
+        start_after: Option<&str>,
+    ) -> BoxStream<'static, Result<ObjectMeta>> {
+        let store = self.clone();
+        let prefix = prefix.to_owned();
+        let start_after = start_after.map(str::to_owned);
+        Box::pin(futures::stream::unfold(
+            ListState {
+                store,
+                prefix,
+                start_after,
+                marker: None,
+                started: false,
+                buffer: Vec::new().into_iter(),
+            },
+            |mut state| async move {
+                loop {
+                    if let Some(item) = state.buffer.next() {
+                        return Some((item, state));
+                    }
+                    if state.started && state.marker.is_none() {
+                        return None;
+                    }
+                    state.started = true;
+                    match state
+                        .store
+                        .list_page(&state.prefix, state.marker.as_deref(), None, 1000)
+                        .await
+                    {
+                        Ok(page) => {
+                            state.marker = page.next_marker;
+                            let skip = state.start_after.as_deref();
+                            let items: Vec<Result<ObjectMeta>> = page
+                                .blobs
+                                .into_iter()
+                                .filter(|m| skip.is_none_or(|s| m.key.as_str() > s))
+                                .map(Ok)
+                                .collect();
+                            if items.is_empty() && state.marker.is_some() {
+                                continue;
+                            }
+                            state.buffer = items.into_iter();
+                            let item = state.buffer.next();
+                            return item.map(|i| (i, state));
+                        }
+                        Err(e) => return Some((Err(e), state)),
+                    }
+                }
+            },
+        ))
+    }
+
+    async fn list_prefixes(&self, prefix: &str) -> Result<Vec<String>> {
+        let mut out = Vec::new();
+        let mut marker = None;
+        loop {
+            let page = self
+                .list_page(prefix, marker.as_deref(), Some("/"), 1000)
+                .await?;
+            out.extend(page.prefixes);
+            marker = page.next_marker;
+            if marker.is_none() {
+                break;
+            }
+        }
+        out.sort();
+        out.dedup();
+        Ok(out)
+    }
+
+    async fn signed_get_url(&self, key: &str, ttl: Duration) -> Result<Option<String>> {
+        Ok(Some(self.mint_sas(key, ttl).await?))
+    }
+
+    async fn accel_target(&self, key: &str) -> Option<crate::AccelTarget> {
+        let url = self
+            .signed_get_url(key, Duration::from_secs(3600))
+            .await
+            .ok()
+            .flatten()?;
+        Some(crate::AccelTarget {
+            url,
+            authorization: None,
+        })
+    }
+
+    fn supports_compose(&self) -> bool {
+        true
+    }
+
+    fn compose_is_native(&self) -> bool {
+        false
+    }
+
+    async fn compose(
+        &self,
+        dest: &str,
+        sources: &[String],
+        opts: PutOptions,
+    ) -> Result<ObjectMeta> {
+        if sources.is_empty() {
+            return Err(StoreError::InvalidArgument(
+                "compose needs at least one source".into(),
+            ));
+        }
+        let mut sizes = Vec::with_capacity(sources.len());
+        for src in sources {
+            let m = self
+                .head(src)
+                .await?
+                .ok_or_else(|| StoreError::NotFound { key: src.clone() })?;
+            sizes.push(m.size);
+        }
+        let total: u64 = sizes.iter().sum();
+        let upload = Self::upload_id();
+        let mut n = 0u32;
+        for (src, size) in sources.iter().zip(sizes.iter().copied()) {
+            if size == 0 {
+                self.put_block(dest, &upload, n, Bytes::new()).await?;
+                n += 1;
+                continue;
+            }
+            let source_url = if self.path_style {
+                None
+            } else {
+                Some(self.mint_sas(src, Duration::from_secs(3600)).await?)
+            };
+            let mut off = 0u64;
+            while off < size {
+                let end = (off + self.multipart_part_size).min(size);
+                if let Some(source_url) = &source_url {
+                    self.put_block_from_url(dest, &upload, n, source_url, off..end)
+                        .await?;
+                } else {
+                    let result = self
+                        .get(
+                            src,
+                            GetOptions {
+                                range: Some(off..end),
+                                ..GetOptions::default()
+                            },
+                        )
+                        .await?;
+                    let GetResult::Object { body, .. } = result else {
+                        return Err(StoreError::other(anyhow::anyhow!(
+                            "azure compose source unexpectedly returned not modified: {src}"
+                        )));
+                    };
+                    let bytes = util::collect(body, (end - off) as usize).await?;
+                    self.put_block(dest, &upload, n, bytes).await?;
+                }
+                n += 1;
+                off = end;
+            }
+        }
+        self.commit_block_list(dest, &upload, n, &opts, total).await
+    }
+}
+
+struct ListState {
+    store: AzureStore,
+    prefix: String,
+    start_after: Option<String>,
+    marker: Option<String>,
+    started: bool,
+    buffer: std::vec::IntoIter<Result<ObjectMeta>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn service_url_production_is_host_style() {
+        let (u, path) = service_url_for("myacct", "");
+        assert_eq!(u, "https://myacct.blob.core.windows.net");
+        assert!(!path);
+        let (u, path) = service_url_for("myacct", "https://myacct.blob.core.windows.net");
+        assert_eq!(u, "https://myacct.blob.core.windows.net");
+        assert!(!path);
+    }
+
+    #[test]
+    fn service_url_azurite_is_path_style() {
+        let (u, path) = service_url_for("devstoreaccount1", "http://127.0.0.1:10000");
+        assert_eq!(u, "http://127.0.0.1:10000/devstoreaccount1");
+        assert!(path);
+    }
+
+    #[test]
+    fn etag_roundtrip_quotes() {
+        assert_eq!(strip_etag("\"0xABC\""), "0xABC");
+        assert_eq!(strip_etag("&quot;0xABC&quot;"), "0xABC");
+        assert_eq!(AzureStore::quote_etag("0xABC"), "\"0xABC\"");
+        assert_eq!(AzureStore::quote_etag("*"), "*");
+    }
+
+    #[test]
+    fn block_ids_are_scoped_to_an_upload() {
+        let first = AzureStore::block_id("first", 0);
+        let second = AzureStore::block_id("second", 0);
+        assert_ne!(first, second);
+        assert_eq!(first, AzureStore::block_id("first", 0));
+    }
+
+    #[test]
+    fn delegation_key_cache_keeps_a_safe_expiry_margin() {
+        let now = Utc::now();
+        let required = now + chrono::Duration::minutes(30);
+        let valid_expiry = now + chrono::Duration::hours(1);
+        let delegation = UserDelegation {
+            oid: "oid".into(),
+            tid: "tid".into(),
+            start: now.to_rfc3339(),
+            expiry: valid_expiry.to_rfc3339(),
+            expires_at: valid_expiry.to_owned(),
+            service: "b".into(),
+            version: API_VERSION.into(),
+            key: vec![1, 2, 3],
+        };
+        assert_eq!(
+            cached_delegation_key(Some(&delegation), &required, &now)
+                .expect("valid cached key")
+                .key,
+            vec![1, 2, 3]
+        );
+        assert!(delegation_key_is_fresh(&valid_expiry, &required, &now));
+        let exact_margin = required + chrono::Duration::minutes(5);
+        assert!(!delegation_key_is_fresh(&exact_margin, &required, &now));
+        let expired = UserDelegation {
+            expires_at: exact_margin,
+            ..delegation
+        };
+        assert!(cached_delegation_key(Some(&expired), &required, &now).is_none());
+        let near_expiry = now + chrono::Duration::minutes(5);
+        assert!(!delegation_key_is_fresh(&near_expiry, &now, &now));
+    }
+
+    #[test]
+    fn list_xml_blobs_and_prefixes() {
+        let xml = r#"
+<EnumerationResults>
+  <Blobs>
+    <Blob><Name>a/b</Name><Properties><Content-Length>3</Content-Length><Etag>"0x1"</Etag></Properties></Blob>
+    <BlobPrefix><Name>a/c/</Name></BlobPrefix>
+  </Blobs>
+  <NextMarker>more</NextMarker>
+</EnumerationResults>"#;
+        let p = parse_list_xml(xml);
+        assert_eq!(p.blobs.len(), 1);
+        assert_eq!(p.blobs[0].key, "a/b");
+        assert_eq!(p.blobs[0].size, 3);
+        assert_eq!(p.blobs[0].version.as_str(), "0x1");
+        assert_eq!(p.prefixes, vec!["a/c/".to_string()]);
+        assert_eq!(p.next_marker.as_deref(), Some("more"));
+    }
+
+    #[test]
+    fn canonicalized_resource_includes_account_and_sorted_query() {
+        let url = reqwest::Url::parse(
+            "http://127.0.0.1:10000/devstoreaccount1/c/k?comp=list&restype=container",
+        )
+        .unwrap();
+        let r = canonicalize_resource("devstoreaccount1", &url);
+        assert!(r.starts_with("/devstoreaccount1/devstoreaccount1/c/k\n"));
+        assert!(r.contains("\ncomp:list"));
+        assert!(r.contains("\nrestype:container"));
+    }
+
+    #[tokio::test]
+    async fn missing_creds_fail_closed() {
+        let mut cfg = walgit_config::Config::default();
+        cfg.store.backend = walgit_config::StoreBackend::Azure;
+        cfg.store.bucket = "walgit-test".into();
+        cfg.store.azure.account = "devstoreaccount1".into();
+        cfg.store.azure.credential = walgit_config::AzureCredential::AccountKey;
+        cfg.store.azure.account_key_env = "WALGIT_TEST_AZURE_KEY_MUST_NOT_EXIST_9f3a".into();
+        let err = match crate::open_store(&cfg).await {
+            Ok(_) => panic!("missing creds must fail"),
+            Err(e) => e.to_string(),
+        };
+        assert!(
+            err.contains("WALGIT_TEST_AZURE_KEY_MUST_NOT_EXIST_9f3a"),
+            "{err}"
+        );
+    }
+}

--- a/crates/walgit-store/src/azure.rs
+++ b/crates/walgit-store/src/azure.rs
@@ -1,4 +1,5 @@
 //! Azure Blob Storage backend.
+//! LARGE_FILE: Keep one backend cohesive so its authentication, CAS, multipart, compose, and signing invariants are reviewed together.
 //!
 //! Speaks the Blob REST API over `reqwest` with Shared Key (HMAC-SHA256) or
 //! AKS Workload Identity. The REST API keeps account-key/Azurite support and

--- a/crates/walgit-store/src/azure.rs
+++ b/crates/walgit-store/src/azure.rs
@@ -45,6 +45,10 @@ use crate::{
 const API_VERSION: &str = "2021-12-02";
 const IMMUTABLE_CACHE_CONTROL: &str = "public, max-age=31536000, immutable";
 
+const MAX_BLOCKS: u32 = 50_000;
+const BLOB_ALREADY_EXISTS: &str = "BlobAlreadyExists";
+const CONTAINER_BEING_DELETED: &str = "ContainerBeingDeleted";
+
 type HmacSha256 = Hmac<Sha256>;
 
 #[derive(Clone)]
@@ -87,10 +91,12 @@ impl AzureStore {
         let parsed = resolve_azure(cfg)?;
         let http = reqwest::Client::builder()
             .pool_max_idle_per_host(8)
+            .connect_timeout(Duration::from_secs(10))
             .timeout(Duration::from_secs(60))
             .build()?;
         let bulk = reqwest::Client::builder()
             .pool_max_idle_per_host(32)
+            .connect_timeout(Duration::from_secs(10))
             .timeout(Duration::from_secs(3600))
             .build()?;
         Ok(AzureStore {
@@ -224,6 +230,7 @@ impl AzureStore {
     fn get_result_from_response(key: &str, resp: reqwest::Response) -> Result<GetResult> {
         let status = resp.status().as_u16();
         let etag = header_str(resp.headers(), "etag").map(|s| strip_etag(&s));
+        let error_code = header_str(resp.headers(), "x-ms-error-code");
         let content_length =
             header_str(resp.headers(), "content-length").and_then(|s| s.parse::<u64>().ok());
         let total = header_str(resp.headers(), "content-range").and_then(|v| {
@@ -248,30 +255,68 @@ impl AzureStore {
             304 => Ok(GetResult::NotModified {
                 version: Version::new(etag.as_deref().unwrap_or("")),
             }),
-            404 => Err(StoreError::NotFound { key: key.into() }),
-            412 | 409 => Err(StoreError::PreconditionFailed {
-                key: key.into(),
-                current: etag.map(Version::new),
-            }),
-            s if s >= 500 || s == 429 => Err(StoreError::Retryable(anyhow::anyhow!(
-                "azure get status {s}"
-            ))),
-            s => Err(StoreError::Other(anyhow::anyhow!("azure get status {s}"))),
+            _ => Err(Self::classify_status(
+                key,
+                status,
+                etag,
+                error_code.as_deref(),
+                &format!("azure get status {status}"),
+            )),
         }
     }
 
-    fn classify_write(key: &str, status: u16, etag: Option<String>, body: &str) -> StoreError {
+    fn classify_status(
+        key: &str,
+        status: u16,
+        etag: Option<String>,
+        error_code: Option<&str>,
+        detail: &str,
+    ) -> StoreError {
         match status {
             404 => StoreError::NotFound { key: key.into() },
-            412 | 409 => StoreError::PreconditionFailed {
+            409 => match error_code {
+                None | Some(BLOB_ALREADY_EXISTS) => StoreError::PreconditionFailed {
+                    key: key.into(),
+                    current: etag.map(Version::new),
+                },
+                Some(CONTAINER_BEING_DELETED) => StoreError::retryable(anyhow::anyhow!("{detail}")),
+                Some(_) => StoreError::other(anyhow::anyhow!("{detail}")),
+            },
+            412 => StoreError::PreconditionFailed {
                 key: key.into(),
                 current: etag.map(Version::new),
             },
-            s if s >= 500 || s == 429 => {
-                StoreError::Retryable(anyhow::anyhow!("azure status {s}: {body}"))
-            }
-            s => StoreError::Other(anyhow::anyhow!("azure status {s}: {body}")),
+            429 | 500..=599 => StoreError::retryable(anyhow::anyhow!("{detail}")),
+            _ => StoreError::other(anyhow::anyhow!("{detail}")),
         }
+    }
+
+    fn classify_write(
+        key: &str,
+        status: u16,
+        etag: Option<String>,
+        error_code: Option<&str>,
+        body: &str,
+    ) -> StoreError {
+        Self::classify_status(
+            key,
+            status,
+            etag,
+            error_code,
+            &format!("azure status {status}: {body}"),
+        )
+    }
+
+    fn block_count(key: &str, len: u64, part_size: u64) -> Result<u32> {
+        let blocks = len.div_ceil(part_size.max(1)).max(1);
+        if blocks > u64::from(MAX_BLOCKS) {
+            return Err(StoreError::InvalidArgument(format!(
+                "azure put {key}: {len} bytes at a {part_size}-byte part size needs {blocks} blocks, over the service limit of {MAX_BLOCKS}"
+            )));
+        }
+        u32::try_from(blocks).map_err(|_| {
+            StoreError::InvalidArgument(format!("azure put {key}: block count does not fit u32"))
+        })
     }
 
     async fn put_blob(&self, key: &str, body: Bytes, opts: &PutOptions) -> Result<ObjectMeta> {
@@ -294,6 +339,7 @@ impl AzureStore {
         let resp = self.execute(builder, bulk).await?;
         let status = resp.status().as_u16();
         let etag = header_str(resp.headers(), "etag").map(|s| strip_etag(&s));
+        let error_code = header_str(resp.headers(), "x-ms-error-code");
         if (200..300).contains(&status) {
             return Ok(ObjectMeta {
                 key: key.into(),
@@ -302,7 +348,7 @@ impl AzureStore {
             });
         }
         let body = resp.text().await.unwrap_or_default();
-        let mut err = Self::classify_write(key, status, etag, &body);
+        let mut err = Self::classify_write(key, status, etag, error_code.as_deref(), &body);
         if let StoreError::PreconditionFailed { current: c, .. } = &mut err
             && c.is_none()
         {
@@ -338,8 +384,15 @@ impl AzureStore {
         if (200..300).contains(&status) {
             return Ok(());
         }
+        let error_code = header_str(resp.headers(), "x-ms-error-code");
         let body = resp.text().await.unwrap_or_default();
-        Err(Self::classify_write(key, status, None, &body))
+        Err(Self::classify_write(
+            key,
+            status,
+            None,
+            error_code.as_deref(),
+            &body,
+        ))
     }
 
     async fn put_block_from_url(
@@ -369,8 +422,15 @@ impl AzureStore {
         if (200..300).contains(&status) {
             return Ok(());
         }
+        let error_code = header_str(resp.headers(), "x-ms-error-code");
         let body = resp.text().await.unwrap_or_default();
-        Err(Self::classify_write(dest, status, None, &body))
+        Err(Self::classify_write(
+            dest,
+            status,
+            None,
+            error_code.as_deref(),
+            &body,
+        ))
     }
 
     async fn commit_block_list(
@@ -406,6 +466,7 @@ impl AzureStore {
         let resp = self.execute(builder, bulk).await?;
         let status = resp.status().as_u16();
         let etag = header_str(resp.headers(), "etag").map(|s| strip_etag(&s));
+        let error_code = header_str(resp.headers(), "x-ms-error-code");
         if (200..300).contains(&status) {
             return Ok(ObjectMeta {
                 key: key.into(),
@@ -414,7 +475,7 @@ impl AzureStore {
             });
         }
         let body = resp.text().await.unwrap_or_default();
-        let mut err = Self::classify_write(key, status, etag, &body);
+        let mut err = Self::classify_write(key, status, etag, error_code.as_deref(), &body);
         if let StoreError::PreconditionFailed { current: c, .. } = &mut err
             && c.is_none()
         {
@@ -430,6 +491,7 @@ impl AzureStore {
         opts: &PutOptions,
     ) -> Result<ObjectMeta> {
         let size = data.len() as u64;
+        Self::block_count(key, size, self.multipart_part_size)?;
         let part = self.multipart_part_size as usize;
         let upload = Self::upload_id();
         let mut n = 0u32;
@@ -455,6 +517,7 @@ impl AzureStore {
         len: u64,
         opts: &PutOptions,
     ) -> Result<ObjectMeta> {
+        Self::block_count(key, len, self.multipart_part_size)?;
         let part = self.multipart_part_size as usize;
         let upload = Self::upload_id();
         let mut buf = bytes::BytesMut::new();
@@ -499,8 +562,15 @@ impl AzureStore {
         let resp = self.execute(self.http.get(&url), false).await?;
         let status = resp.status().as_u16();
         if !(200..300).contains(&status) {
+            let error_code = header_str(resp.headers(), "x-ms-error-code");
             let body = resp.text().await.unwrap_or_default();
-            return Err(Self::classify_write(prefix, status, None, &body));
+            return Err(Self::classify_write(
+                prefix,
+                status,
+                None,
+                error_code.as_deref(),
+                &body,
+            ));
         }
         let body = resp
             .text()
@@ -971,9 +1041,16 @@ impl ObjectStore for AzureStore {
                 }))
             }
             404 => Ok(None),
-            s => {
+            status => {
+                let error_code = header_str(resp.headers(), "x-ms-error-code");
                 let body = resp.text().await.unwrap_or_default();
-                Err(Self::classify_write(key, s, None, &body))
+                Err(Self::classify_write(
+                    key,
+                    status,
+                    None,
+                    error_code.as_deref(),
+                    &body,
+                ))
             }
         }
     }
@@ -1021,22 +1098,22 @@ impl ObjectStore for AzureStore {
         }
         let response = self.execute(builder, false).await?;
         let status = response.status().as_u16();
-        match status {
-            200 | 202 => Ok(()),
-            404 if if_version.is_none() => Ok(()),
-            404 => Err(StoreError::NotFound { key: key.into() }),
-            412 | 409 => match self.head(key).await? {
-                None => Err(StoreError::NotFound { key: key.into() }),
-                Some(meta) => Err(StoreError::PreconditionFailed {
-                    key: key.into(),
-                    current: Some(meta.version),
-                }),
-            },
-            status => {
-                let body = response.text().await.unwrap_or_default();
-                Err(Self::classify_write(key, status, None, &body))
+        if matches!(status, 200 | 202) {
+            return Ok(());
+        }
+        if status == 404 && if_version.is_none() {
+            return Ok(());
+        }
+        let error_code = header_str(response.headers(), "x-ms-error-code");
+        let body = response.text().await.unwrap_or_default();
+        let mut err = Self::classify_write(key, status, None, error_code.as_deref(), &body);
+        if let StoreError::PreconditionFailed { current, .. } = &mut err {
+            match self.head(key).await? {
+                Some(meta) => *current = Some(meta.version),
+                None => return Err(StoreError::NotFound { key: key.into() }),
             }
         }
+        Err(err)
     }
 
     fn list(
@@ -1154,7 +1231,22 @@ impl ObjectStore for AzureStore {
                 .ok_or_else(|| StoreError::NotFound { key: src.clone() })?;
             sizes.push(m.size);
         }
-        let total: u64 = sizes.iter().sum();
+        let total = sizes.iter().try_fold(0u64, |sum, size| {
+            sum.checked_add(*size).ok_or_else(|| {
+                StoreError::InvalidArgument("azure compose source sizes overflow u64".into())
+            })
+        })?;
+        let blocks = sizes.iter().try_fold(0u64, |sum, size| {
+            let source_blocks = size.div_ceil(self.multipart_part_size).max(1);
+            sum.checked_add(source_blocks).ok_or_else(|| {
+                StoreError::InvalidArgument("azure compose block count overflow u64".into())
+            })
+        })?;
+        if blocks > u64::from(MAX_BLOCKS) {
+            return Err(StoreError::InvalidArgument(format!(
+                "azure compose {dest}: {blocks} blocks exceed the service limit of {MAX_BLOCKS}"
+            )));
+        }
         let upload = Self::upload_id();
         let mut n = 0u32;
         for (src, size) in sources.iter().zip(sizes.iter().copied()) {
@@ -1244,6 +1336,43 @@ mod tests {
         let second = AzureStore::block_id("second", 0);
         assert_ne!(first, second);
         assert_eq!(first, AzureStore::block_id("first", 0));
+    }
+
+    #[test]
+    fn azure_conflicts_preserve_retry_semantics() {
+        let precondition =
+            AzureStore::classify_status("k", 409, None, Some(BLOB_ALREADY_EXISTS), "blob exists");
+        assert!(matches!(
+            precondition,
+            StoreError::PreconditionFailed { .. }
+        ));
+
+        let transient = AzureStore::classify_status(
+            "k",
+            409,
+            None,
+            Some(CONTAINER_BEING_DELETED),
+            "container deleting",
+        );
+        assert!(transient.is_retryable());
+
+        let permanent =
+            AzureStore::classify_status("k", 409, None, Some("LeaseIdMissing"), "lease conflict");
+        assert!(!permanent.is_retryable());
+        assert!(!matches!(permanent, StoreError::PreconditionFailed { .. }));
+    }
+
+    #[test]
+    fn azure_rejects_uploads_above_the_block_limit() {
+        let max_len = u64::from(MAX_BLOCKS) * 32;
+        assert_eq!(
+            AzureStore::block_count("k", max_len, 32).expect("maximum fits"),
+            MAX_BLOCKS
+        );
+        assert!(matches!(
+            AzureStore::block_count("k", max_len + 1, 32),
+            Err(StoreError::InvalidArgument(_))
+        ));
     }
 
     #[test]

--- a/crates/walgit-store/src/gcs.rs
+++ b/crates/walgit-store/src/gcs.rs
@@ -20,7 +20,7 @@ use google_cloud_storage::streaming_source::StreamingSource;
 
 use crate::{
     ByteStream, GetOptions, GetResult, ObjectMeta, ObjectStore, PutBody, PutMode, PutOptions,
-    Result, StoreError, Version,
+    Result, StoreError, Version, util,
 };
 
 const IMMUTABLE_CACHE_CONTROL: &str = "public, max-age=31536000, immutable";
@@ -237,31 +237,6 @@ impl GcsStore {
         })
     }
 
-    /// Bulk keys: pack data and side-files, bundles, LFS (everything that is
-    /// large or read by range); the rest is control plane.
-    #[expect(
-        clippy::case_sensitive_file_extension_comparisons,
-        reason = "Object store control keys use exact case-sensitive suffixes"
-    )]
-    fn is_bulk_key(key: &str) -> bool {
-        // Pack data + side-files, bundle *files* (not `bundles/list.pb`), LFS
-        // objects. Everything else — manifest, log, checkpoints, leases,
-        // bundle list, policy — is control plane and must never wait for a
-        // bulk permit (prod 2026-08-20: `bundles/list.pb` (753 B) classified
-        // bulk sat 455–472 s behind 32 stripes on the bulk semaphore while
-        // info/refs waited for it).
-        let name = key.rsplit('/').next().unwrap_or(key);
-        if name.ends_with(".pb") || name.ends_with(".json") {
-            return false;
-        }
-        key.contains("/wal/")
-            || key.starts_with("wal/")
-            || key.contains("/bundles/")
-            || key.starts_with("bundles/")
-            || key.contains("/lfs/")
-            || key.starts_with("lfs/")
-    }
-
     /// What a resume needs (pools/creds are Arc'd inside; cheap).
     fn clone_for_resume(&self) -> BulkHttp {
         BulkHttp {
@@ -289,7 +264,7 @@ impl GcsStore {
         key: &str,
         ranged: bool,
     ) -> (&Storage, Option<tokio::sync::OwnedSemaphorePermit>) {
-        if ranged || Self::is_bulk_key(key) {
+        if ranged || util::is_bulk_key(key) {
             let i = self
                 .bulk_next
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
@@ -593,7 +568,7 @@ impl GcsStore {
         key: &str,
         range: Option<std::ops::Range<u64>>,
     ) -> Result<ByteStream> {
-        if self.creds.is_some() && (range.is_some() || Self::is_bulk_key(key)) {
+        if self.creds.is_some() && (range.is_some() || util::is_bulk_key(key)) {
             return Ok(self.bulk_http_read(key, range, None).await?.2);
         }
         let (client, permit) = self.data_client(key, range.is_some()).await;
@@ -721,7 +696,7 @@ impl ObjectStore for GcsStore {
 
         // Direct read (no if_none_match, or if_none_match with non-numeric
         // version that can never match a GCS generation).
-        if self.creds.is_some() && (opts.range.is_some() || Self::is_bulk_key(key)) {
+        if self.creds.is_some() && (opts.range.is_some() || util::is_bulk_key(key)) {
             let if_gen = match &opts.if_match {
                 Some(v) => match parse_generation(v) {
                     Some(g) => Some(g),
@@ -1484,7 +1459,7 @@ fn urlencode(s: &str) -> String {
 
 #[cfg(test)]
 mod bulk_key_tests {
-    use super::GcsStore;
+    use crate::util;
 
     #[test]
     fn control_plane_keys_are_never_bulk() {
@@ -1497,7 +1472,7 @@ mod bulk_key_tests {
             "prefix/repos/o/r/policy.json",
             "prefix/repos/o/r/cache/api/v1/abc.json",
         ] {
-            assert!(!GcsStore::is_bulk_key(k), "{k} must be control plane");
+            assert!(!util::is_bulk_key(k), "{k} must be control plane");
         }
         for k in [
             "prefix/repos/o/r/wal/abc.pack",
@@ -1506,7 +1481,7 @@ mod bulk_key_tests {
             "prefix/repos/o/r/bundles/weekly/2026-abc.bundle",
             "prefix/repos/o/r/lfs/objects/ab/cd/abcd",
         ] {
-            assert!(GcsStore::is_bulk_key(k), "{k} must be bulk");
+            assert!(util::is_bulk_key(k), "{k} must be bulk");
         }
     }
 }

--- a/crates/walgit-store/src/lib.rs
+++ b/crates/walgit-store/src/lib.rs
@@ -7,7 +7,7 @@
 //! * conditional writes (`Create` = if-absent, `Update(v)` = CAS on version),
 //! * conditional deletes, range reads, streaming bodies, prefix listing.
 //!
-//! [`Version`] is opaque to callers: GCS generation, S3/rustfs `ETag`, or a
+//! [`Version`] is opaque to callers: GCS generation, S3/Azure ETag, or a
 //! counter in [`memory::MemoryStore`]. Callers must never parse it.
 
 use std::{fmt, ops::Range, pin::Pin, sync::Arc};
@@ -18,6 +18,8 @@ use tracing::Instrument;
 
 pub mod coord;
 pub use coord::CoordError;
+#[cfg(feature = "azure")]
+pub mod azure;
 pub mod fault;
 #[cfg(feature = "gcs")]
 pub mod gcs;
@@ -197,7 +199,7 @@ pub type Result<T, E = StoreError> = std::result::Result<T, E>;
 
 #[async_trait::async_trait]
 pub trait ObjectStore: Send + Sync + 'static {
-    /// Human-readable backend id for logs/metrics ("gcs", "s3", "memory").
+    /// Human-readable backend id for logs/metrics ("gcs", "s3", "azure", "memory").
     fn backend(&self) -> &'static str;
     /// Whether this store is a prefixing wrapper. Used to avoid duplicate
     /// operation spans when prefixes are nested.
@@ -241,23 +243,22 @@ pub trait ObjectStore: Send + Sync + 'static {
 
     /// How a trusted edge (nginx `X-Accel-Redirect`) fetches `key` on the client's behalf:
     /// a URL it can `proxy_pass`, and the `Authorization` value to send with it, if any.
-    /// GCS: the path-style URL + this process's bearer token (no token on the edge, nothing to
-    /// refresh). S3: a presigned GET URL (`Range` is not a signed header, so the edge may slice).
+    /// GCS: the path-style URL + this process's bearer token. S3 and Azure:
+    /// a signed GET URL (`Range` is not a signed header, so the edge may slice).
     /// Backends without one return `None` and the bytes stream through walgit.
     async fn accel_target(&self, _key: &str) -> Option<AccelTarget> {
         None
     }
 
-    /// Whether [`ObjectStore::compose`] is available. GCS: native (<= 32 sources
-    /// per call, no data movement). S3: multipart `UploadPartCopy` (server-side copy,
-    /// no bytes through this process beyond one small part).
+    /// Whether [`ObjectStore::compose`] is available. GCS: native (<= 32 sources).
+    /// S3: multipart `UploadPartCopy`. Azure: `Put Block From URL` + block list.
     fn supports_compose(&self) -> bool {
         false
     }
 
-    /// Whether compose is a metadata operation (GCS). When false (S3) a compose still
-    /// moves bytes inside the bucket, so callers that only want a parallel upload of one
-    /// file use the backend's multipart PUT instead of part objects + compose.
+    /// Whether compose is a metadata operation (GCS). When false (S3/Azure),
+    /// bytes move inside the store, so callers that only want a parallel upload
+    /// use the backend's multipart PUT instead of part objects + compose.
     fn compose_is_native(&self) -> bool {
         false
     }
@@ -655,6 +656,16 @@ pub async fn open_store(cfg: &walgit_config::Config) -> anyhow::Result<DynStore>
             #[cfg(not(feature = "gcs"))]
             {
                 anyhow::bail!("gcs backend requires the `gcs` feature")
+            }
+        }
+        walgit_config::StoreBackend::Azure => {
+            #[cfg(feature = "azure")]
+            {
+                Arc::new(azure::AzureStore::new(&cfg.store).await?)
+            }
+            #[cfg(not(feature = "azure"))]
+            {
+                anyhow::bail!("azure backend requires the `azure` feature")
             }
         }
     };

--- a/crates/walgit-store/src/util.rs
+++ b/crates/walgit-store/src/util.rs
@@ -3,6 +3,22 @@ use futures::StreamExt;
 
 use crate::{ByteStream, Result, StoreError};
 
+/// Pack data and side-files, bundle files, and LFS objects use the bulk
+/// transport. Metadata such as manifests, logs, and bundle lists stays on the
+/// control transport even when its path contains a bulk directory.
+pub fn is_bulk_key(key: &str) -> bool {
+    let name = key.rsplit('/').next().unwrap_or(key);
+    if name.ends_with(".pb") || name.ends_with(".json") {
+        return false;
+    }
+    key.contains("/wal/")
+        || key.starts_with("wal/")
+        || key.contains("/bundles/")
+        || key.starts_with("bundles/")
+        || key.contains("/lfs/")
+        || key.starts_with("lfs/")
+}
+
 /// Collect a byte stream. `size_hint` pre-allocates.
 pub async fn collect(mut body: ByteStream, size_hint: usize) -> Result<Bytes> {
     let mut first: Option<Bytes> = None;

--- a/crates/walgit-store/tests/contract.rs
+++ b/crates/walgit-store/tests/contract.rs
@@ -17,9 +17,10 @@
 //! isolation, large streamed put/get roundtrip with checksum, and the
 //! multipart upload path.
 //!
-//! The suite is executed against `MemoryStore` always, and against `S3Store`
-//! when `WALGIT_TEST_S3_ENDPOINT` is set. `GcsStore` is tested when
-//! `WALGIT_TEST_GCS_BUCKET` is set (`StoreGcs` adds that wrapper).
+//! The suite is executed against `MemoryStore` always, against `S3Store`
+//! when `WALGIT_TEST_S3_ENDPOINT` is set, against `GcsStore` when
+//! `WALGIT_TEST_GCS_BUCKET` is set, and against `AzureStore` when
+//! `WALGIT_TEST_AZURE_ENDPOINT` is set.
 
 use std::ops::Range;
 use std::sync::Arc;
@@ -53,6 +54,7 @@ pub async fn run_contract(store: DynStore, prefix: &str) {
     test_list(&store, &p("list")).await;
     test_large_streamed_roundtrip(&store, &p("large")).await;
     test_multipart_path(&store, &p("multi")).await;
+    test_concurrent_multipart_create(&store, &p("multipart-concurrent")).await;
     test_compose(&store, &p("compose")).await;
 }
 
@@ -668,6 +670,49 @@ async fn test_multipart_path(store: &DynStore, key: &str) {
     let _ = store.delete(key, None).await;
 }
 
+/// Concurrent multipart Create attempts must commit blocks from exactly one upload.
+async fn test_concurrent_multipart_create(store: &DynStore, key: &str) {
+    let _ = store.delete(key, None).await;
+    let size = 6 * 1024 * 1024;
+    let attempts = (1u8..=8).map(|value| {
+        let store = store.clone();
+        let key = key.to_owned();
+        async move {
+            store
+                .put(
+                    &key,
+                    PutBody::Bytes(Bytes::from(vec![value; size])),
+                    PutOptions::from(PutMode::Create),
+                )
+                .await
+        }
+    });
+    let results = futures::future::join_all(attempts).await;
+    assert_eq!(
+        results.iter().filter(|result| result.is_ok()).count(),
+        1,
+        "exactly one multipart Create must win"
+    );
+    for result in results.iter().filter(|result| result.is_err()) {
+        assert!(
+            matches!(result, Err(StoreError::PreconditionFailed { .. })),
+            "loser must be a precondition failure: {result:?}"
+        );
+    }
+    let response = store
+        .get(key, GetOptions::default())
+        .await
+        .expect("get concurrent multipart winner");
+    let (_, body) = collect_body(response).await;
+    assert_eq!(body.len(), size);
+    let winner = body[0];
+    assert!(
+        body.iter().all(|byte| *byte == winner),
+        "committed object mixed blocks from concurrent uploads"
+    );
+    let _ = store.delete(key, None).await;
+}
+
 // ---- test wrappers -----------------------------------------------------
 
 #[tokio::test]
@@ -770,6 +815,79 @@ async fn gcs_contract() {
         let _ = store.delete(&m.key, None).await;
     }
     eprintln!("[gcs_contract] cleanup done ({count} objects deleted)");
+}
+
+#[cfg(feature = "azure")]
+#[tokio::test]
+async fn azure_contract() {
+    let endpoint = match std::env::var("WALGIT_TEST_AZURE_ENDPOINT") {
+        Ok(value) => value,
+        Err(_) => {
+            eprintln!("skipping azure_contract: WALGIT_TEST_AZURE_ENDPOINT not set");
+            return;
+        }
+    };
+    let account =
+        std::env::var("WALGIT_TEST_AZURE_ACCOUNT").unwrap_or_else(|_| "devstoreaccount1".into());
+    let bucket = std::env::var("WALGIT_TEST_BUCKET").unwrap_or_else(|_| "walgit-test".into());
+    std::env::var("AZURE_STORAGE_ACCOUNT_KEY")
+        .expect("AZURE_STORAGE_ACCOUNT_KEY required for Azure tests");
+    let prefix = format!("contract-test-{}", uuid::Uuid::new_v4().simple());
+
+    let cfg = walgit_config::StoreConfig {
+        backend: walgit_config::StoreBackend::Azure,
+        bucket,
+        prefix: prefix.clone(),
+        azure: walgit_config::AzureConfig {
+            endpoint,
+            account,
+            credential: walgit_config::AzureCredential::AccountKey,
+            account_key_env: "AZURE_STORAGE_ACCOUNT_KEY".into(),
+        },
+        multipart_threshold: bytesize::ByteSize::mib(5),
+        multipart_part_size: bytesize::ByteSize::mib(4),
+        ..Default::default()
+    };
+    let store = walgit_store::azure::AzureStore::new(&cfg)
+        .await
+        .expect("AzureStore::new");
+    store
+        .ensure_container()
+        .await
+        .expect("ensure Azure container");
+    let store: DynStore = Arc::new(store);
+
+    run_contract(store.clone(), &prefix).await;
+
+    let sas_key = format!("{prefix}/sas-probe");
+    store
+        .put(
+            &sas_key,
+            PutBody::Bytes(Bytes::from_static(b"sas-body")),
+            PutOptions::from(PutMode::Overwrite),
+        )
+        .await
+        .expect("put SAS probe");
+    let url = store
+        .signed_get_url(&sas_key, std::time::Duration::from_secs(3600))
+        .await
+        .expect("signed_get_url")
+        .expect("Azure signed_get_url must return a URL");
+    let response = reqwest::Client::new()
+        .get(url)
+        .send()
+        .await
+        .expect("SAS GET");
+    assert!(response.status().is_success(), "SAS GET failed");
+    assert_eq!(
+        response.bytes().await.expect("SAS body"),
+        Bytes::from_static(b"sas-body")
+    );
+
+    let objects = store.list(&prefix, None).collect::<Vec<_>>().await;
+    for meta in objects.into_iter().flatten() {
+        let _ = store.delete(&meta.key, None).await;
+    }
 }
 
 /// Control plane must stay fast under bulk load (prod 2026-08-20: a 184-byte

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -23,7 +23,7 @@ Read `AGENTS.md` first (design §1–§2, decisions §3; the original layout/pha
   `GetResult::{NotModified,Object}`, `PutMode::{Overwrite,Create,Update(Version)}`, `PutBody::{Bytes,Stream,File}`,
   `PutOptions`, `StoreError::{NotFound,PreconditionFailed{current},Retryable,InvalidArgument,Other}`,
   `ObjectStoreExt`, `Prefixed`, `memory::MemoryStore`, `util::{collect,once,file_stream,backoff,retry}`),
-  placeholder modules `coord.rs`, `gcs.rs`, `s3.rs`.
+  backend modules `gcs.rs`, `s3.rs`, and `azure.rs`.
 - `walgit-config`: `Config` for walgit.toml (+ `WALGIT__` env overrides, `PORT`); `Config::with_settings` accepts
   only `[bundles]`, `[maintenance]`, `[compaction]` and `[upstream]` in repo-scoped settings.
 
@@ -152,19 +152,22 @@ pub fn instance_id() -> &'static str; // explicit instance name/id, hostname+pid
 pub enum CoordError { Store(StoreError), Decode(prost::DecodeError), Aborted, RetriesExhausted{key, attempts}, Other }
 ```
 
-## walgit-store backends (owners: StoreS3, StoreGcs)
+## walgit-store backends (owners: StoreS3, StoreGcs, StoreAzure)
 
 ```rust
 // s3.rs
 pub struct S3Store; impl S3Store { pub async fn new(cfg: &walgit_config::StoreConfig) -> anyhow::Result<Self>; }
 // gcs.rs
 pub struct GcsStore; impl GcsStore { pub async fn new(cfg: &walgit_config::StoreConfig) -> anyhow::Result<Self>; }
+// azure.rs
+pub struct AzureStore; impl AzureStore { pub async fn new(cfg: &walgit_config::StoreConfig) -> anyhow::Result<Self>; }
 // lib.rs
 pub async fn open_store(cfg: &walgit_config::Config) -> anyhow::Result<DynStore>; // by cfg.store.backend, applies Prefixed(cfg.store_prefix())
 ```
 Contract tests: `crates/walgit-store/tests/contract.rs` with a `run_contract(store: DynStore)` suite executed for
 memory always, for s3 when `WALGIT_TEST_S3_ENDPOINT` set (bucket `WALGIT_TEST_BUCKET`, default "walgit-test"),
-for gcs when `WALGIT_TEST_GCS_BUCKET` set.
+for gcs when `WALGIT_TEST_GCS_BUCKET` set, and for azure when `WALGIT_TEST_AZURE_ENDPOINT` set (account
+`WALGIT_TEST_AZURE_ACCOUNT`, key `AZURE_STORAGE_ACCOUNT_KEY`).
 
 ## walgit-wal (owner: Wal)
 

--- a/justfile
+++ b/justfile
@@ -80,12 +80,20 @@ dev-store:
 dev-store-stop:
     podman compose down
 
+
+# Start the Azure Blob emulator on :10000.
+dev-azurite:
+    podman compose up -d azurite
+
+dev-azurite-stop:
+    podman compose stop azurite
 # --- tests -------------------------------------------------------------------
 # Tiers (all hermetic: in-memory store, tempdir caches, real `git` binary):
 #   test       fast tier, < 30 s: every unit/integration test not marked #[ignore]
 #   test-slow  benches/soak: #[ignore]d tests (20k-ref push, 466k-ref render, ...)
 #   test-s3    store contract against local rustfs (just dev-store)
 #   test-gcs   store contract against a real bucket (writes under a unique prefix)
+#   test-azure store contract against local Azurite (just dev-azurite)
 
 # Fast hermetic tier (< 30 s): every test not marked #[ignore].
 # Fast tier (default, < 1 min): unit tests + the quick integration suites.
@@ -155,6 +163,13 @@ store-test-s3:
     AWS_ACCESS_KEY_ID=walgit-dev \
     AWS_SECRET_ACCESS_KEY=walgit-dev-secret \
     cargo test -p walgit-store --test contract -- --nocapture
+
+# Store contract against local Azurite. Set AZURE_STORAGE_ACCOUNT_KEY to Azurite's well-known key.
+test-azure:
+    WALGIT_TEST_AZURE_ENDPOINT=http://127.0.0.1:10000 \
+    WALGIT_TEST_AZURE_ACCOUNT=devstoreaccount1 \
+    WALGIT_TEST_BUCKET=walgit-test \
+    cargo test -p walgit-store --features azure --test contract -- azure_contract --nocapture
 
 # Run all walgit-store tests (memory + S3 if env set).
 store-test-all:

--- a/walgit.example.toml
+++ b/walgit.example.toml
@@ -65,7 +65,7 @@ anonymous_read = true             # must be false in oidc mode
 # trusted_forwarders = []                  # principals allowed to set X-Walgit-Principal (a front in front of a push broker)
 
 [store]
-backend = "s3"                    # "s3" (AWS, MinIO, rustfs, R2, Ceph, …) | "gcs" | "memory" (tests)
+backend = "s3"                    # "s3" (AWS, MinIO, rustfs, R2, Ceph, …) | "gcs" | "azure" | "memory" (tests)
 bucket = "walgit"
 prefix = ""                       # global key prefix inside the bucket
 max_retries = 8                   # retries on retryable store errors (jittered backoff)
@@ -85,6 +85,13 @@ direct_connectivity = true
 # signing_service_account = "sa@project.iam.gserviceaccount.com"   # for bundles/lfs serve_via = "signed_url"
 bulk_clients = 4                  # separate data channels for pack/idx/side-file/bundle/LFS bytes + ranged reads
 bulk_concurrency = 32             # max concurrent bulk requests per process (control plane never queues behind them)
+
+[store.azure]
+endpoint = ""                    # empty = https://{account}.blob.core.windows.net; Azurite: http://127.0.0.1:10000
+account = ""                     # storage account name; required for the azure backend
+credential = "workload_identity" # "workload_identity" (AKS: AZURE_CLIENT_ID, AZURE_TENANT_ID,
+                                  # AZURE_FEDERATED_TOKEN_FILE) | "account_key" (Azurite and service SAS)
+account_key_env = "AZURE_STORAGE_ACCOUNT_KEY"
 
 [cache]
 dir = "/tmp/walgit"               # local materialized repos (+ tls/ for a self-signed certificate)

--- a/walgit.standalone.toml
+++ b/walgit.standalone.toml
@@ -66,6 +66,12 @@ force_path_style = true
 # backend = "gcs"
 # bucket = "my-walgit-bucket"
 # prefix = ""
+# Azure Blob on AKS (the pod supplies workload identity environment variables):
+# backend = "azure"
+# bucket = "my-walgit-container"
+# [store.azure]
+# account = "mywalgitaccount"
+# credential = "workload_identity"
 
 # Bundles (docs/BUNDLE_URI_DESIGN.md): one weekly full, then **chained** incrementals — each daily on the
 # previous daily (the first on the weekly), each hourly on the previous hourly (restarting from every new


### PR DESCRIPTION
> **TL;DR:** Azure deployments currently need an extra S3/GCS service or a private Walgit fork; this adds an optional Azure Blob backend that implements the existing `ObjectStore` contract.

- **Problem:** Walgit cannot use the object store that is native to Azure.
- **Outcome:** `store.backend = "azure"` supports workload identity in Azure and account-key authentication for Azurite or explicit deployments.
- **Scope:** Store implementation, config, contract tests, local Azurite recipe, and the existing D42/contract documentation.
- **Compatibility:** S3, GCS, and memory behavior stay unchanged; Azure remains an optional Cargo feature.

<!-- pr-overview-images:start -->

## PR overview

<img alt="azure-architecture-trust-v2.png" src="https://github.com/user-attachments/assets/05db62af-b4b0-47ca-a489-eb476495779a" />
<img alt="azure-runtime-flow-v2.png" src="https://github.com/user-attachments/assets/3db73860-a637-402f-a7b6-37b4f0688ace" />

<!-- pr-overview-images:end -->

## Why

Running Walgit on Azure currently requires a second cloud storage protocol or an out-of-tree patch. That adds another service, credential model, and failure boundary even though Azure Blob can provide the versioned object operations Walgit's store contract needs.

This work ports the Azure backend from #1 by @kzu onto current `main`, then narrows and hardens it for the current contract. Thank you to Daniel Cazzulino for the original implementation.

## What changed

### Azure store contract

- Add `AzureStore` behind the optional `azure` feature.
- Use Blob ETags as opaque version tokens for compare-and-swap writes.
- Implement conditional and ranged reads, `head`, listing, deletion, streaming uploads, multipart block uploads, compose, and signed GET URLs.
- Give each multipart upload unique fixed-width block IDs. Concurrent uploads to one key cannot commit each other's staged blocks.
- Use the control or bulk HTTP client from the same key/range classifier as GCS.

### Authentication and trust boundaries

- Require an explicit credential mode: `workload_identity` or `account_key`.
- Keep account keys outside TOML. Config names the environment variable that contains the key.
- Reject non-HTTPS workload-identity Blob endpoints.
- Allow account-key HTTP only for loopback endpoints such as Azurite.
- Cache Azure user-delegation keys with an expiry safety margin instead of requesting one per signed URL.

### Local development and documentation

- Add an Azurite Compose service and `just dev-azurite` / `just test-azure` recipes.
- Extend the shared store contract suite with Azure and concurrent multipart coverage.
- Document Azure as a first-class backend in D42 and `docs/CONTRACT.md`.
- Keep the existing round-trip budget unchanged.

## Security

Workload identity is the production default and does not require an account key. Account-key mode reads one explicitly configured environment variable and never accepts the key as a TOML value. Workload tokens cannot be sent to plaintext custom endpoints. Signed URLs use service SAS with an account key or a cached user-delegation key with workload identity.

## How this was tested

1. `cargo fmt --all -- --check`
   - Proves the Rust changes match repository formatting.
2. `cargo check -p walgit-cli --locked`
   - Proves the full CLI compiles with the Azure feature enabled by `walgit-cli`.
3. `cargo test -p walgit-config`
   - 18 tests passed, including explicit credential modes and unknown-field rejection.
4. `cargo test -p walgit-store --features azure`
   - 56 tests passed across unit and contract support code.
5. `just test-azure` against local Azurite
   - Proved ETag CAS, conditional GET, range/head/list/delete, streaming and multipart writes, compose fallback, signed GET, and concurrent multipart isolation.
6. Adversarial review found and this branch fixed six issues:
   1. cross-upload block ID collisions;
   2. bulk-client use for all GETs;
   3. one delegation-key request per signed URL;
   4. workload tokens allowed on HTTP custom endpoints;
   5. a healthy-path `HEAD` before conditional delete;
   6. control-client use for bulk-key writes.

## After merge

No existing deployment changes behavior. Azure users enable the Cargo feature, select `store.backend = "azure"`, and configure one credential mode. A live Azure deployment should still verify workload-identity token exchange, user-delegation SAS, and server-side `Put Block From URL`; Azurite covers the account-key and local compose paths.
