### PR TITLE
fix: require admin permission for repository deletion

### DIFF
--- a/crates/walgit-server/src/admin.rs
+++ b/crates/walgit-server/src/admin.rs
@@ -39,13 +39,13 @@ pub async fn create(
     }
 }
 
-/// `DELETE /{owner}/{repo}` — delete manifest + all objects under the repo prefix.
+/// `DELETE /{owner}/{repo}` — admin-only deletion of the manifest and every object under the repo prefix.
 pub async fn delete(
     st: &AppState,
     route: &RepoRoute,
     headers: &HeaderMap,
 ) -> Result<Response, ApiError> {
-    let _principal = st.auth.require_write(headers).await.map_err(auth_err)?;
+    let _principal = st.auth.require_admin(headers).await.map_err(auth_err)?;
     st.registry.delete(&route.id).await.map_err(wal_err)?;
     Ok((StatusCode::NO_CONTENT, "").into_response())
 }

--- a/crates/walgit-server/src/auth.rs
+++ b/crates/walgit-server/src/auth.rs
@@ -55,7 +55,8 @@ fn unix_now() -> Option<u64> {
 pub struct Principal {
     pub name: String,
     pub write: bool,
-    /// PUT/DELETE settings and `policy.json`. Independent of `write` (push).
+    /// Repository deletion and PUT/DELETE settings and `policy.json`.
+    /// Independent of `write` (push and repository creation).
     pub admin: bool,
     pub anonymous: bool,
 }
@@ -713,7 +714,7 @@ impl Authenticator {
         }
     }
 
-    /// Require a principal that may mutate settings and `policy.json`.
+    /// Require a principal that may delete repositories or mutate settings and `policy.json`.
     pub async fn require_admin(&self, headers: &HeaderMap) -> Result<Principal, AuthError> {
         let p = self.authenticate(headers).await?;
         if p.admin {

--- a/crates/walgit-server/tests/api_v1.rs
+++ b/crates/walgit-server/tests/api_v1.rs
@@ -456,3 +456,79 @@ async fn d26_prefix_form_matches_v1_alias() -> TestResult {
     );
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn repository_delete_requires_admin() -> TestResult {
+    let server = Server::start_with_tweak(|c| {
+        c.server.auth.mode = walgit_config::AuthMode::Token;
+        c.server.auth.anonymous_read = false;
+        c.server.auth.tokens = vec![
+            walgit_config::StaticToken {
+                principal: "writer".into(),
+                token: "writer-token".into(),
+                token_env: None,
+                write: true,
+                admin: false,
+            },
+            walgit_config::StaticToken {
+                principal: "admin".into(),
+                token: "admin-token".into(),
+                token_env: None,
+                write: true,
+                admin: true,
+            },
+        ];
+    })
+    .await?;
+
+    let writer = [("Authorization", "Bearer writer-token")];
+    let admin = [("Authorization", "Bearer admin-token")];
+
+    assert_eq!(
+        req(&server, reqwest::Method::PUT, "/secure/delete/api", &writer,)
+            .await?
+            .0,
+        201,
+        "write permission still creates repositories"
+    );
+
+    for path in [
+        "/secure/delete",
+        "/secure/delete/api",
+        "/secure/delete/api-browser",
+    ] {
+        assert_eq!(
+            req(&server, reqwest::Method::DELETE, path, &writer)
+                .await?
+                .0,
+            403,
+            "non-admin deletion through {path}"
+        );
+    }
+    assert_eq!(
+        req(&server, reqwest::Method::GET, "/secure/delete/api", &writer,)
+            .await?
+            .0,
+        200,
+        "forbidden deletion must leave the repository intact"
+    );
+
+    assert_eq!(
+        req(
+            &server,
+            reqwest::Method::DELETE,
+            "/secure/delete/api",
+            &admin,
+        )
+        .await?
+        .0,
+        204
+    );
+    assert_eq!(
+        req(&server, reqwest::Method::GET, "/secure/delete/api", &admin,)
+            .await?
+            .0,
+        404
+    );
+    Ok(())
+}

--- a/walgit.example.toml
+++ b/walgit.example.toml
@@ -48,8 +48,8 @@ anonymous_read = true             # must be false in oidc mode
 #   { principal = "alice", token_env = "WALGIT_TOKEN_ALICE", write = true, admin = true },
 #   { principal = "ci", token = "literal-secret", write = false },
 # ]
-# admin_emails = []                # oidc: emails that may PUT/DELETE settings and policy.json
-# admin_domains = []               # oidc: email domains that may PUT/DELETE settings and policy.json
+# admin_emails = []                # oidc: emails that may delete repos or PUT/DELETE settings and policy.json
+# admin_domains = []               # oidc: email domains that may delete repos or PUT/DELETE settings and policy.json
 # issuer = "https://id.example.com"        # oidc: discovery at <issuer>/.well-known/openid-configuration
 # allowed_domains = ["example.com"]        # oidc: email domains admitted (email_verified required)
 # allowed_emails = []                      # oidc: individual identities admitted

--- a/web/API.md
+++ b/web/API.md
@@ -261,7 +261,7 @@ Sorted, `[]` for an unknown/empty owner (200, not 404). Cache: SWR.
 Ref-level summary: head (`null` when unborn), O(1) ref counts from the ref
 index, URLs. `404` for an unknown repo. Cache: SWR + `ETag: "<head sha>"`.
 `PUT` creates the repository (write permission; `201`/`200`), `DELETE`
-removes it — the same handlers as `PUT|DELETE /{owner}/{repo}`.
+removes it (admin permission) — the same handlers as `PUT|DELETE /{owner}/{repo}`.
 `GET|PUT|DELETE …/policy` is the push policy document (`docs/POLICY.md`).
 
 `GET|PUT|DELETE /{o}/{r}/api/settings` (D24, 2026-08-21) is the repository's **settings in the WAL**: a TOML document

--- a/web/sdk/README.md
+++ b/web/sdk/README.md
@@ -47,7 +47,8 @@ repos.owners.repos("acme")                   → ["monorepo", …]
 repos.repo("acme/monorepo")                     → RepoClient (no request)
 
 r.get()                                      → { owner, name, full_name, head, branches, tags, clone_url, html_url, api_url }
-r.create() / r.delete()                      → write permission
+r.create()                                   → write permission
+r.delete()                                   → admin permission
 r.refs()                                     → { head: {name, sha} | null }
 r.branches({ prefix, q, after, n })          → { refs: [{name, sha}], more }      (one page; tags likewise)
 r.tags({ … })

--- a/web/sdk/repos.ts
+++ b/web/sdk/repos.ts
@@ -603,7 +603,7 @@ export class RepoClient {
   async create(opts?: CallOptions): Promise<void> {
     await this.client.json<unknown>(this.p, opts, { method: "PUT" });
   }
-  /** Delete the repository (write permission). Irreversible. */
+  /** Delete the repository (admin permission). Irreversible. */
   async delete(opts?: CallOptions): Promise<void> {
     await this.client.json<unknown>(this.p, opts, { method: "DELETE" });
   }

--- a/web/src/pages/ApiPage.tsx
+++ b/web/src/pages/ApiPage.tsx
@@ -94,7 +94,7 @@ export function ApiPage() {
             <Row path="/api/v1/owners/{owner}/repos" desc="Repository names under one owner." cache="SWR" />
             <Row
               path={`/${r}/api`}
-              desc={<>Repo summary: <code>{`{owner,name,full_name,head,branches,tags,clone_url,html_url,api_url}`}</code> (O(1) ref counts). <code>PUT</code> creates, <code>DELETE</code> removes (write).</>}
+              desc={<>Repo summary: <code>{`{owner,name,full_name,head,branches,tags,clone_url,html_url,api_url}`}</code> (O(1) ref counts). <code>PUT</code> creates (write), <code>DELETE</code> removes (admin).</>}
               cache="SWR + ETag"
             />
             <Row path={`…/${r}/refs`} desc={<>Default branch only: <code>{`{head:{name,sha}|null}`}</code>. O(1) whatever the ref count.</>} cache="SWR + ETag" />


### PR DESCRIPTION
Fixes #10

A write token with `admin = false` could delete the whole repo. 
One `DELETE` and repo gone

Repro before this fix:
1. Configure a token with `write = true, admin = false`
2. Create a repo with that token
3. Call `DELETE /owner/repo/api`
4. It returns `204`; the next `GET` returns `404`

Deletion now uses the existing admin check. 
Creation still needs write permission. 
Added coverage for the root, API, and browser routes, plus updated the docs

Tests:
`just web-build`
`just test`
`just e2e`
`just warnings`
