### PR TITLE
Add a strict clippy gate to the justfile and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 name: CI
 
 # The repository had no build/test workflow: only pages.yml (a site deploy). A workspace that did
-# not compile reached main because nothing ran cargo on push. This runs `just ci` — the same three
-# tiers AGENTS.md documents (warnings, test, e2e) — so CI and a contributor's laptop cannot drift.
+# not compile reached main because nothing ran cargo on push. This runs `just ci` — the same
+# tiers AGENTS.md documents (warnings, clippy, test, e2e) — so CI and a contributor's laptop cannot drift.
 # The tier definitions live in the justfile, never duplicated here.
 
 on:
@@ -54,6 +54,7 @@ jobs:
         run: just web-build
 
       - run: just warnings
+      - run: just clippy
       - run: just test
 
   e2e:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -434,7 +434,8 @@ Decision identifiers are stable; gaps in the numbering are intentional.
   old readers within the retention window.
 - Web: pnpm + Vite, `pnpm run build` must pass oxlint/tsc. Config: `walgit.example.toml` documents every key;
   change it with the code.
-- Test tiers: `just test` (fast, < 1 min), `just e2e`, `just warnings`, `just ci` = all three; the **simulation
+- Test tiers: `just test` (fast, < 1 min), `just e2e`, `just warnings`, `just clippy` (the
+  `[workspace.lints]` set, `-D warnings`), `just ci` = all four; the **simulation
   suite** `cargo test -p walgit-server --test sim` (fault links per instance over one truth store: crash,
   partition, stale, lost response, orphan scenarios + randomized seeds `WALGIT_SIM_SEEDS`/`WALGIT_SIM_SEED`);
   `just test-slow` (ignored benches); `tests/e2e.sh` against a running server (`WALGIT_E2E_BASE_URL`,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,49 @@ edition = "2024"
 license = "MIT"
 rust-version = "1.90"
 
+# The lint gate: `just clippy` runs `cargo clippy --workspace --all-targets -- -D warnings`
+# against this table (every crate opts in with `[lints] workspace = true`). Test code is
+# exempt from the panic-path restriction lints via clippy.toml (allow-unwrap-in-tests etc.).
+[workspace.lints.rust]
+# The two statvfs call sites must carry an explicit #[allow(unsafe_code)] — new unsafe
+# should be a reviewed decision, not a habit.
+unsafe_code = "warn"
+
+[workspace.lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+
+# Panic paths in production code. A panic here is a 500 (CatchPanicLayer) at best and an
+# aborted push at worst; recoverable failures must travel as Results. Known-infallible
+# cases (constant HeaderValue parses, checked-then-unwrap invariants) should say so with
+# a targeted #[allow] or an expect() naming the invariant.
+unwrap_used = "warn"
+expect_used = "warn"
+panic = "warn"
+indexing_slicing = "warn"
+string_slice = "warn"
+unchecked_time_subtraction = "warn"
+
+# Debugging leftovers must not reach main.
+dbg_macro = "deny"
+todo = "deny"
+unimplemented = "deny"
+
+# Unsafe hygiene: every unsafe block carries a // SAFETY: comment and does one thing.
+undocumented_unsafe_blocks = "deny"
+multiple_unsafe_ops_per_block = "warn"
+
+# Holding a sync lock across .await stalls the whole worker thread.
+await_holding_lock = "warn"
+await_holding_refcell_ref = "warn"
+
+# Pedantic members that are documentation/naming style, not safety — pure noise here.
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+module_name_repetitions = "allow"
+must_use_candidate = "allow"
+similar_names = "allow"
+too_many_lines = "allow"
+
 [workspace.dependencies]
 walgit-proto = { path = "crates/walgit-proto" }
 walgit-store = { path = "crates/walgit-store" }

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,8 @@
+# The panic-path restriction lints in [workspace.lints.clippy] (unwrap_used, panic,
+# indexing_slicing, ...) target production code; tests may panic freely — that is how
+# they fail.
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true
+allow-panic-in-tests = true
+allow-indexing-slicing-in-tests = true
+allow-dbg-in-tests = true

--- a/crates/walgit-bundle/Cargo.toml
+++ b/crates/walgit-bundle/Cargo.toml
@@ -32,3 +32,6 @@ tokio = { workspace = true, features = ["full", "test-util"] }
 [features]
 default = []
 wal = ["dep:walgit-wal"]
+
+[lints]
+workspace = true

--- a/crates/walgit-cli/Cargo.toml
+++ b/crates/walgit-cli/Cargo.toml
@@ -50,3 +50,6 @@ axum.workspace = true
 tempfile.workspace = true
 
 [dev-dependencies]
+
+[lints]
+workspace = true

--- a/crates/walgit-config/Cargo.toml
+++ b/crates/walgit-config/Cargo.toml
@@ -12,3 +12,6 @@ serde.workspace = true
 toml.workspace = true
 humantime-serde.workspace = true
 bytesize.workspace = true
+
+[lints]
+workspace = true

--- a/crates/walgit-git/Cargo.toml
+++ b/crates/walgit-git/Cargo.toml
@@ -41,3 +41,6 @@ tempfile.workspace = true
 tempfile.workspace = true
 libc.workspace = true
 flate2.workspace = true
+
+[lints]
+workspace = true

--- a/crates/walgit-proto/Cargo.toml
+++ b/crates/walgit-proto/Cargo.toml
@@ -11,3 +11,6 @@ prost-types.workspace = true
 
 [build-dependencies]
 prost-build.workspace = true
+
+[lints]
+workspace = true

--- a/crates/walgit-server/Cargo.toml
+++ b/crates/walgit-server/Cargo.toml
@@ -68,3 +68,6 @@ tempfile.workspace = true
 [dev-dependencies]
 reqwest.workspace = true
 rcgen = { workspace = true, features = ["x509-parser"] }
+
+[lints]
+workspace = true

--- a/crates/walgit-store/Cargo.toml
+++ b/crates/walgit-store/Cargo.toml
@@ -43,3 +43,6 @@ sha1 = { workspace = true }
 bytesize = { workspace = true }
 uuid = { workspace = true }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
+
+[lints]
+workspace = true

--- a/crates/walgit-wal/Cargo.toml
+++ b/crates/walgit-wal/Cargo.toml
@@ -38,3 +38,6 @@ chrono.workspace = true
 [dev-dependencies]
 tempfile.workspace = true
 tokio = { workspace = true, features = ["full", "test-util"] }
+
+[lints]
+workspace = true

--- a/justfile
+++ b/justfile
@@ -108,8 +108,14 @@ warnings:
     fi
     echo "no rustc warnings"
 
+# Clippy, workspace-wide, all targets, warnings are errors. The lint set lives in
+# [workspace.lints] in Cargo.toml; test code is exempt from the panic-path restriction
+# lints via clippy.toml (allow-unwrap-in-tests etc.).
+clippy:
+    {{t15}} cargo clippy --workspace --all-targets -- -D warnings
+
 # Everything that must be green before a merge (what CI runs).
-ci: warnings test e2e
+ci: warnings clippy test e2e
 
 # Slow tier: #[ignore]d benches/soaks (20k-ref push, 466k-ref render, ...).
 test-slow:


### PR DESCRIPTION
Proposes turning on clippy workspace-wide via `workspace.lints`. This is expected to be red until fixes for each failure are merged.