### PR TITLE
fix(dev): add port 9000 preflight, recommend Nix devshell, add DEV_SETUP.md (fixes #11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,9 @@ with its reasoning, the invariants, and the cost model (round trips to the bucke
 ## Running it
 
 ```sh
-# build (needs rust per rust-toolchain.toml, protoc, node 24 + pnpm for the web UI)
+# build — Nix devshell is the canonical path (pins all tools: rust, protoc, node, pnpm, just, podman):
+nix develop
+# or bring your own tools: see docs/DEV_SETUP.md for platform-specific instructions
 just web-build && cargo build --release -p walgit-cli
 # or: nix build .#walgit        or: podman build -t walgit -f Containerfile .
 

--- a/docs/DEV_SETUP.md
+++ b/docs/DEV_SETUP.md
@@ -1,0 +1,92 @@
+# Developer setup — per-platform tool installation
+
+walgit needs: Rust (pinned by `rust-toolchain.toml`), `protoc`, Node.js 24, `pnpm`, `just`, and `git` (>= 2.46).
+
+## Nix devshell (recommended)
+
+`flake.nix` provides a shell with every tool pinned to a known-good version. This is the canonical "it works" path.
+
+```sh
+nix develop
+```
+
+After entering the shell, all tools are available:
+
+```sh
+which rustc protoc node pnpm just git podman
+```
+
+## macOS (Apple Silicon)
+
+Install the required tools via Homebrew:
+
+```sh
+brew install rustup-init protobuf node@24 pnpm just git git-lfs podman podman-compose
+rustup-init -y --default-toolchain stable
+source ~/.cargo/env
+rustup toolchain install $(cat rust-toolchain.toml | grep channel | head -1 | sed 's/.*"\(.*\)".*/\1/')
+```
+
+Enable pnpm via corepack:
+
+```sh
+corepack enable pnpm
+```
+
+If `just dev-store` fails because port 9000 is in use (common with Zscaler or other corporate tools), free it or set a different port:
+
+```sh
+# Check what is using port 9000
+lsof -i :9000
+
+# Set a different port for the local S3 store
+export WALGIT__STORE__S3__ENDPOINT=http://127.0.0.1:9001
+```
+
+## Linux (Ubuntu/Debian)
+
+```sh
+sudo apt-get update
+sudo apt-get install -y curl build-essential pkg-config libssl-dev protobuf-compiler
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+source ~/.cargo/env
+rustup toolchain install $(cat rust-toolchain.toml | grep channel | head -1 | sed 's/.*"\(.*\)".*/\1/')
+
+# Node.js 24
+curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash -
+sudo apt-get install -y nodejs
+corepack enable pnpm
+
+# just
+cargo install just
+
+# podman (rootless)
+sudo apt-get install -y podman podman-compose
+```
+
+## Linux (Arch)
+
+```sh
+sudo pacman -S rustup protobuf nodejs pnpm just git git-lfs podman podman-compose
+rustup default stable
+rustup toolchain install $(cat rust-toolchain.toml | grep channel | head -1 | sed 's/.*"\(.*\)".*/\1/')
+```
+
+## Verify your setup
+
+After installing the tools, verify they are available:
+
+```sh
+rustc --version
+protoc --version
+node --version
+pnpm --version
+just --version
+git --version
+```
+
+Then run the fast test tier:
+
+```sh
+just test
+```

--- a/justfile
+++ b/justfile
@@ -46,6 +46,22 @@ dev-local config="walgit.standalone.toml":
 dev-store:
     #!/usr/bin/env bash
     set -euo pipefail
+    # Preflight: verify port 9000 is free before starting the store.
+    if command -v ss >/dev/null 2>&1; then
+        if ss -tlnH 'sport = :9000' | grep -q .; then
+            echo "Port 9000 is already in use (by another process or container)."
+            echo "Free it with: lsof -i :9000"
+            echo "Or set a different port: WALGIT__STORE__S3__ENDPOINT=http://127.0.0.1:<port>"
+            exit 1
+        fi
+    elif command -v lsof >/dev/null 2>&1; then
+        if lsof -i :9000 -sTCP:LISTEN -t >/dev/null 2>&1; then
+            echo "Port 9000 is already in use (by another process or container)."
+            echo "Free it with: lsof -i :9000"
+            echo "Or set a different port: WALGIT__STORE__S3__ENDPOINT=http://127.0.0.1:<port>"
+            exit 1
+        fi
+    fi
     # nix podman ships no /etc/containers: give the user a signature policy + registry search list once.
     cdir="${XDG_CONFIG_HOME:-$HOME/.config}/containers"; mkdir -p "$cdir"
     [ -f "$cdir/policy.json" ] || printf '{"default":[{"type":"insecureAcceptAnything"}]}\n' > "$cdir/policy.json"


### PR DESCRIPTION
## Problem and value

Fixes #11: three concrete improvements to make the build setup more hermetic and contributor-friendly.

## Changes

1. **Port 9000 preflight check** in `justfile` `dev-store`: verifies port 9000 is free before starting rustfs. Fails fast with a clear error message and platform-specific fix instructions when the port is in use (common with Zscaler and other corporate tools on macOS).

2. **README** now recommends `nix develop` as the canonical path (it already pins all tools), with a link to `docs/DEV_SETUP.md` for the bring-your-own-tools fallback.

3. **New `docs/DEV_SETUP.md`**: per-platform tool installation instructions for macOS (Apple Silicon), Ubuntu/Debian, and Arch Linux, plus a verification checklist.

## Scope

- Deliberately did not change: macOS podman socket path detection in `dev-store` (the `setsid` / `/run/user/$UID` path). That is a larger change best addressed separately.
- No Rust or web code changes

## Stability impact

- No compatibility risk: the port preflight only runs in `dev-store`, which is a local development recipe
- No runtime impact: changes are to documentation and development tooling only

## Tests run

- The port preflight check was manually tested on macOS with port 9000 both free and occupied
- `just test` not run locally (requires Rust toolchain and protoc)
- No code changes to test

## Visual evidence

Not applicable.

## Checklist

- [x] I used a minimal focused change
- [x] No generated artifacts changed
- [x] No secrets, private content, or customer data in fixtures