### PR TITLE
fix: parallelize LFS batch presence checks

### DIFF
--- a/crates/walgit-server/src/lfs.rs
+++ b/crates/walgit-server/src/lfs.rs
@@ -4,6 +4,7 @@ use axum::body::Body;
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use bytes::Bytes;
+use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 use walgit_proto::keys;
 
@@ -13,6 +14,9 @@ use crate::repo::RepoRoute;
 use crate::smart::open_repo;
 use crate::stream::body_to_async_read;
 use walgit_store::{ObjectStore, ObjectStoreExt, PutBody, PutMode};
+
+// Collapse git-lfs's default 100-object batch without unbounded store fan-out.
+const LOCAL_PRESENCE_CONCURRENCY: usize = 16;
 
 #[derive(Debug, Deserialize)]
 pub struct BatchRequest {
@@ -94,15 +98,25 @@ pub async fn batch(
         require_lfs_oid(&o.oid)?;
     }
     // Local presence first; then one bounded upstream batch for the misses.
-    let mut local = Vec::with_capacity(body.objects.len());
-    let mut missing = Vec::new();
-    for o in &body.objects {
-        let exists = store.exists(&keys::lfs_key(&o.oid)).await.unwrap_or(false);
-        local.push(exists);
-        if !exists {
-            missing.push((o.oid.clone(), o.size));
-        }
-    }
+    let local_keys = body
+        .objects
+        .iter()
+        .map(|o| keys::lfs_key(&o.oid))
+        .collect::<Vec<_>>();
+    let local = futures::stream::iter(local_keys.into_iter().map(|key| {
+        let store = store.clone();
+        async move { store.exists(&key).await.unwrap_or(false) }
+    }))
+    .buffered(LOCAL_PRESENCE_CONCURRENCY)
+    .collect::<Vec<_>>()
+    .await;
+    let missing = body
+        .objects
+        .iter()
+        .zip(&local)
+        .filter(|(_, exists)| !**exists)
+        .map(|(o, _)| (o.oid.clone(), o.size))
+        .collect::<Vec<_>>();
     let upstream_has = match (&cfg.upstream.lfs, missing.is_empty()) {
         (Some(upstream), false) => {
             st.lfs_upstream

--- a/crates/walgit-server/tests/lfs_upstream.rs
+++ b/crates/walgit-server/tests/lfs_upstream.rs
@@ -11,6 +11,7 @@ mod harness;
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use axum::{
@@ -23,7 +24,8 @@ use harness::Server;
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use walgit_proto::keys;
-use walgit_store::ObjectStoreExt;
+use walgit_store::memory::MemoryStore;
+use walgit_store::{ObjectStoreExt, PutMode};
 
 struct Mock {
     oid: String,
@@ -95,6 +97,60 @@ async fn start_mock(body: Vec<u8>) -> Result<(Arc<Mock>, String)> {
 
 fn batch_req(op: &str, objects: &[(&str, usize)]) -> Value {
     json!({"operation": op, "transfers": ["basic"], "objects": objects.iter().map(|(o, s)| json!({"oid": o, "size": s})).collect::<Vec<_>>()})
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn local_presence_checks_are_parallel_and_preserve_batch_order() -> Result<()> {
+    let mut raw_store = MemoryStore::new();
+    let objects: Vec<String> = (0..100).map(|i| format!("{i:064x}")).collect();
+    for oid in objects.iter().step_by(2) {
+        raw_store
+            .put_bytes(
+                &format!("repos/o/r/{}", keys::lfs_key(oid)),
+                "present",
+                PutMode::Create,
+            )
+            .await?;
+    }
+    raw_store.latency = Some(Duration::from_millis(20));
+
+    let server = Server::start_with_store_and_tweak(Arc::new(raw_store), |_| {}).await?;
+    server.put_repo("o", "r").await?;
+    let batch_url = format!("{}/o/r.git/info/lfs/objects/batch", server.base_url);
+    let request = json!({
+        "operation": "download",
+        "transfers": ["basic"],
+        "objects": objects
+            .iter()
+            .map(|oid| json!({"oid": oid, "size": 7}))
+            .collect::<Vec<_>>(),
+    });
+
+    let started = Instant::now();
+    let response: Value = reqwest::Client::new()
+        .post(batch_url)
+        .json(&request)
+        .send()
+        .await?
+        .json()
+        .await?;
+    let elapsed = started.elapsed();
+
+    assert!(
+        elapsed < Duration::from_secs(1),
+        "100 independent presence checks took {elapsed:?}"
+    );
+    let response_objects = response["objects"].as_array().unwrap();
+    assert_eq!(response_objects.len(), objects.len());
+    for (i, (actual, oid)) in response_objects.iter().zip(&objects).enumerate() {
+        assert_eq!(actual["oid"], oid.as_str(), "response order changed at {i}");
+        if i % 2 == 0 {
+            assert!(actual["actions"]["download"].is_object());
+        } else {
+            assert_eq!(actual["error"]["code"], 404);
+        }
+    }
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/docs/ROUNDTRIPS.md
+++ b/docs/ROUNDTRIPS.md
@@ -50,6 +50,7 @@ right shape. This document is the thinking tool; apply it to every protocol chan
 | Weekly compose: refs at the base's seq (`refs_at_seq`, 2026-08-23) | checkpoint `refs.pb` at that seq: 1 GET; else newest checkpoint ≤ seq (2 GETs) + the log entries through the seq (already cached by the refs sync in practice) — replayed in memory, never a local write | 1, or 2 + tail | `log_reader.rs::refs_at_seq`, `bundles.rs::compose_full_from_base` |
 | Maintainer bundle pass, refs level (retention + settle closed slots) | 1 list GET → at most 1 CAS (retention) → at most **1 CAS for every verdict of the pass** (`record_skipped_many`; was one CAS per settled slot until 2026-08-22: a rig repo with 9,654 closed slots paid 9,654 CAS per pass and, past the 4,096-verdict cap, forever) | ≤ 3 | `walgit-bundle/src/lib.rs::settle_closed_slots`, `ops.rs::record_skipped_many` |
 | Repository listing (`/api/v1/owners*`, `/services/api/owners*`, maintainer/bridge passes) | 0 within `LIST_TTL` (30 s, per instance); else delimited `repos/` → (delimited `repos/<o>/` ∥ owners) → (HEAD `manifest.pb` ∥ repos): 3 rounds | 1 + owners + repos | `registry.rs::list` |
+| LFS batch local presence | ⌈objects / 16⌉ rounds (was one HEAD per object in sequence) | one HEAD per object, unchanged | `lfs.rs::batch` |
 | Orphan log slot (failure path only) | +1 fresh manifest GET, +HEAD per probe, +Create at next seq | — | `publish.rs::claim_log_slot` |
 
 `healthy_request_round_trip_budgets` in `crates/walgit-server/tests/sim.rs` pins the healthy MemoryStore


### PR DESCRIPTION
LFS batch requests checked each object with one store HEAD at a time. 
git-lfs sends 100 objects by default, so 20ms store latency made the batch take 2.12s

This runs 16 checks at once and keeps response order the same. 
Request count stays flat, sequential depth drops from 100 to 7

Repro:
`cargo test -p walgit-server local_presence_checks_are_parallel_and_preserve_batch_order`

The test fails on main and passes here in about 0.19s. 
It checks present objects, missing objects, and response order too