### PR TITLE
Accept a static token entry that names only token_env

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ each repository one maintainer (placement globs) and you are done.
 
 | mode | who gets in | how git authenticates |
 |---|---|---|
-| `none` | everyone is `anon` with write — loopback experiments | nothing |
+| `none` | everyone is `anon` with write and admin — loopback experiments | nothing |
 | `token` | static `tokens` in the config (`token_env` reads the secret from the environment) | `Authorization: Bearer <token>`, or the token as an HTTP Basic password |
 | `oidc` | any OpenID Connect issuer (`issuer`, `oauth_client_id/secret`, `allowed_domains`/`allowed_emails`): Google, Entra, Okta, Auth0, Keycloak, Dex, GitLab… | a **walgit access token**: sign in once in the browser, create one at `/_auth/tokens`, paste it into the installer. Stateless (HMAC with `session_secret`, `access_token_ttl`); rotating the secret revokes all. ID tokens from the issuer (`audiences`) and static `tokens` work too. |
 

--- a/crates/walgit-config/src/lib.rs
+++ b/crates/walgit-config/src/lib.rs
@@ -209,6 +209,7 @@ pub enum AuthMode {
 pub struct StaticToken {
     pub principal: String,
     /// Read from env var if set, else literal.
+    #[serde(default)]
     pub token: String,
     #[serde(default)]
     pub token_env: Option<String>,
@@ -1938,6 +1939,25 @@ audiences = ["walgit-cli", "https://git.example.com"]
         let err = Config::parse("[store]\nbucket = \"b\"\n[server.auth]\nmode = \"token\"\n")
             .unwrap_err();
         assert!(err.to_string().contains("tokens"), "{err}");
+        // `token_env` alone is a whole entry: the README quick start writes exactly this.
+        let readme = Config::parse(
+            "[store]\nbucket = \"b\"\n[server.auth]\nmode = \"token\"\ntokens = [{ principal = \"me\", token_env = \"WALGIT_TOKEN_ME\", write = true }]\n",
+        )
+        .unwrap();
+        let t = &readme.server.auth.tokens[0];
+        assert_eq!(t.principal, "me");
+        assert!(t.token.is_empty(), "{:?}", t.token);
+        assert_eq!(t.token_env.as_deref(), Some("WALGIT_TOKEN_ME"));
+        assert!(t.write && !t.admin);
+        // Neither key names a secret, so the entry could never let anyone in.
+        let err = Config::parse(
+            "[store]\nbucket = \"b\"\n[server.auth]\nmode = \"token\"\ntokens = [{ principal = \"me\", write = true }]\n",
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("needs `token` or `token_env`"),
+            "{err}"
+        );
         // oidc: anonymous_read off, an allowlist, and a way in.
         let err = Config::parse("[store]\nbucket = \"b\"\n[server.auth]\nmode = \"oidc\"\nanonymous_read = false\nallowed_domains = [\"example.com\"]\n").unwrap_err();
         assert!(err.to_string().contains("way in"), "{err}");

--- a/walgit.example.toml
+++ b/walgit.example.toml
@@ -3,7 +3,7 @@
 # Start from walgit.standalone.toml for a first run; come here when you need a key.
 # Normative bundle-slot semantics: docs/BUNDLE_URI_DESIGN.md §4.
 # Every key can also be set from the environment: WALGIT__SECTION__KEY=value (TOML value syntax).
-# Validate with: walgit config check walgit.toml
+# Validate with: walgit --config walgit.toml config check
 
 [server]
 listen = "127.0.0.1:8080"        # default; `mode = none` is refused unless this is loopback. Public bind: 0.0.0.0 with token/oidc.


### PR DESCRIPTION
Fixes #22 (thanks @jeonck, same diagnosis).

The README quick-start config doesn't load. `StaticToken.token` in `crates/walgit-config/src/lib.rs` has no `#[serde(default)]` while `token_env` does, so an entry that only names an environment variable dies in serde with `missing field token` before `validate()` gets a look. Every shipped example of `token_env` (`README.md`, `walgit.example.toml`, `walgit.standalone.toml`) hits it.

Three commits:

1. Add the default and extend `auth_modes_validate_fail_closed` with the README entry, plus an entry that names neither key so the fail-closed path stays covered (`validate` already refuses it).
2. `walgit.example.toml` told you to run `walgit config check walgit.toml`, which exits 2 because the path is the global `--config` flag; it now says `walgit --config walgit.toml config check`.
3. The README auth table said mode `none` gives write; it gives admin too.

Checked with the README block written to a file: `config check` prints `missing field token` on main and `config OK` with this. `cargo test -p walgit-config` passes.
