### PR TITLE
Run the events, follow and policy suites in just test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           version: 10
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
           cache-dependency-path: web/pnpm-lock.yaml
 
@@ -75,7 +75,7 @@ jobs:
           version: 10
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
           cache-dependency-path: web/pnpm-lock.yaml
       - name: Build the SPA and the SDK

--- a/README.md
+++ b/README.md
@@ -155,7 +155,8 @@ and turns on `transfer.bundleURI`. `?repo=owner/name` clones right after.
 just test          # fast hermetic tier (< 1 min): unit + quick integration, in-memory store, real git
 just e2e           # real git against the server (~20 s)
 just warnings      # zero rustc warnings across all targets
-just ci            # all of the above
+just clippy        # the [workspace.lints] set across all targets, warnings are errors
+just ci            # warnings, clippy, test, e2e: everything that must be green before a merge
 cargo test -p walgit-server --test sim     # fault-injection simulation (crashes, partitions, stale reads)
 just test-s3       # store contract against local rustfs
 ```

--- a/justfile
+++ b/justfile
@@ -83,7 +83,7 @@ dev-store-stop:
 test:
     {{t5}} cargo test --workspace --lib --bins
     {{t5}} cargo test -p walgit-store -p walgit-git -p walgit-wal -p walgit-bundle --tests
-    {{t5}} cargo test -p walgit-server --test web_api --test web_ui --test api_v1 --test static_http --test maintain --test routing_prefix --test lfs_upstream --test drain
+    {{t5}} cargo test -p walgit-server --test web_api --test web_ui --test api_v1 --test static_http --test maintain --test routing_prefix --test lfs_upstream --test drain --test events --test follow --test policy
 
 # Smart-HTTP end-to-end against real git (≈ 20 s) — run when touching smart.rs/receive/upload-pack/wal.
 e2e *ARGS:


### PR DESCRIPTION
The `just test` recipe names eight of the walgit-server test binaries. `events.rs`, `follow.rs` and `policy.rs` in `crates/walgit-server/tests/` aren't in that list or in any other recipe, so they have never run locally or in CI (CI just calls `just test`). This adds them. They pass as they are: seven tests in about five seconds.

Two small things fixed while in there:

- `.github/workflows/ci.yml` pinned Node 22 while `README.md`, `flake.nix` and the `Containerfile` all say 24; both setup-node steps now match.
- The README's developing block called `just ci` "all of the above" but the list left out `just clippy`, which the recipe runs.

Checked by running the recipe's third command as it now reads: eleven suites, 45 tests, all green. No Rust changes. I couldn't run the GitHub workflow itself, so the Node bump is verified by reading, not by a run.
