### PR TITLE
Install libprotobuf-dev in the Containerfile build stage

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -24,7 +24,7 @@ RUN pnpm run build && test -f dist/index.html && test -f dist/repos.js
 
 # ---- 2. rust build ------------------------------------------------------------------------
 FROM docker.io/library/rust:1.97-bookworm AS build
-RUN apt-get update && apt-get install -y --no-install-recommends protobuf-compiler pkg-config cmake perl python3 \
+RUN apt-get update && apt-get install -y --no-install-recommends protobuf-compiler libprotobuf-dev pkg-config cmake perl python3 \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /src
 COPY Cargo.toml Cargo.lock rust-toolchain.toml ./


### PR DESCRIPTION
Fixes #21.

The Rust stage of the `Containerfile` installs `protobuf-compiler`, which gives you `protoc` but not the well-known `.proto` files that `walgit/v1/wal.proto` imports (`google/protobuf/timestamp.proto`), so walgit-proto's build script fails and the image never builds. On Debian those files ship in `libprotobuf-dev`; this adds it to the same apt line.

@jeonck checked both packages in the stage's base image (`rust:1.97-bookworm`) in #21. I haven't rebuilt the image on this machine; happy to set up a build if you'd like to see it green first.
