### PR TITLE
fix(store): uniform compose part sizes for Cloudflare R2

### DIFF
--- a/crates/walgit-store/src/s3.rs
+++ b/crates/walgit-store/src/s3.rs
@@ -546,7 +546,12 @@ impl ObjectStore for S3Store {
         opts: PutOptions,
     ) -> Result<ObjectMeta> {
         const MIN_PART: u64 = 5 * 1024 * 1024;
-        const COPY_PART: u64 = 1024 * 1024 * 1024; // <= 5 GiB per UploadPartCopy
+        // Copy in MIN_PART-sized slices (not the 5 GiB S3 maximum): R2 requires every
+        // non-trailing part of a multipart upload to have the SAME length, so the copy
+        // granularity must equal the upload granularity (MIN_PART) for mixed
+        // upload/copy layouts to complete. S3 accepts uniform parts just as well;
+        // a 5 GiB compose needs <= 1024 copy requests, a 30 GB one ~6k (limit 10k).
+        const COPY_PART: u64 = MIN_PART;
         if sources.is_empty() {
             return Err(StoreError::InvalidArgument(
                 "compose needs at least one source".into(),

--- a/crates/walgit-store/tests/contract.rs
+++ b/crates/walgit-store/tests/contract.rs
@@ -689,10 +689,12 @@ async fn s3_contract() {
         prefix: prefix.clone(),
         s3: walgit_config::S3Config {
             endpoint: endpoint.clone(),
-            region: "us-east-1".into(),
+            region: std::env::var("WALGIT_TEST_S3_REGION").unwrap_or_else(|_| "us-east-1".into()),
             access_key_env: "AWS_ACCESS_KEY_ID".into(),
             secret_key_env: "AWS_SECRET_ACCESS_KEY".into(),
-            force_path_style: true,
+            force_path_style: std::env::var("WALGIT_TEST_S3_FORCE_PATH_STYLE")
+                .map(|v| v != "false")
+                .unwrap_or(true),
         },
         multipart_threshold: bytesize::ByteSize::mib(5),
         multipart_part_size: bytesize::ByteSize::mib(5),


### PR DESCRIPTION
## Problem

Bundle builds against Cloudflare R2 fail forever with:

```
bundle task: store error: s3 complete multipart: service error
```

(repeats every maintenance pass; the server log shows `receive-pack`-side pushes are fine, only `compose` fails at `CompleteMultipartUpload`).

## Root cause

R2 requires **every non-trailing part of a multipart upload to have the same length** (it answers `InvalidPart: All non-trailing parts must have the same length.`), whereas S3 only requires non-trailing parts to be >= 5 MiB.

`compose` cut copy ranges at `COPY_PART = 1 GiB`. For the standard bundle shape — a small bundle header in front of a large pack — the layout is one 5 MiB uploaded part (header + pack prefix) followed by one large copied part (the rest of the pack), so R2 rejects the Complete. The contract test's compose case only exercises a ~1 MiB trailing copy, a layout that happens to be legal, which is why this never showed up before.

## Fix

Cut copy parts at `MIN_PART` instead of 1 GiB, so **every non-trailing part — uploaded or copied — is exactly 5 MiB** and only the trailing part may differ. S3 accepts uniform parts just as well; part counts stay small (a 5 GiB compose needs <= 1024 copy requests, a 30 GB one ~6k, below the 10k part limit).

## Verification

- Reproduced against a real R2 bucket with a raw-SDK probe (31-byte header + 46 MiB source → `UploadPart(5 MiB)` + `UploadPartCopy(41 MB)`): before the fix Complete fails with `InvalidPart`, after it succeeds and the content round-trips (head, tail, total size).
- Full store contract suite against R2 (virtual-hosted style, region `auto`): all cases pass, including `test_compose`.
- Production: a 48.7 MiB weekly bundle now builds successfully on R2 (`bundles/list.pb` published).

Second commit is a small test affordance: `s3_contract` hardcodes path-style addressing and `us-east-1`, which makes it impossible to run the suite against R2/OSS; the two env overrides keep rustfs defaults unchanged.