### PR TITLE
Require an explicit issuer in oidc mode

### DIFF
--- a/crates/walgit-config/src/lib.rs
+++ b/crates/walgit-config/src/lib.rs
@@ -145,7 +145,8 @@ pub struct AuthConfig {
     pub tokens: Vec<StaticToken>,
     /// OIDC issuer (`oidc` mode). Discovery at `<issuer>/.well-known/openid-configuration`
     /// supplies the JWKS, authorization and token endpoints. Any compliant provider works
-    /// (Google, Microsoft Entra, Okta, Auth0, Keycloak, Dex, GitLab, ...).
+    /// (Google, Microsoft Entra, Okta, Auth0, Keycloak, Dex, GitLab, ...). No default:
+    /// `Config::validate` refuses `oidc` mode until it is set.
     pub issuer: String,
     /// Email domains accepted by `oidc` (the `email` claim, `email_verified` required).
     pub allowed_domains: Vec<String>,
@@ -1054,7 +1055,7 @@ impl Default for AuthConfig {
             mode: AuthMode::None,
             anonymous_read: true,
             tokens: vec![],
-            issuer: "https://accounts.google.com".into(),
+            issuer: String::new(),
             allowed_domains: vec![],
             allowed_emails: vec![],
             audiences: vec![],
@@ -1938,10 +1939,12 @@ audiences = ["walgit-cli", "https://git.example.com"]
         let err = Config::parse("[store]\nbucket = \"b\"\n[server.auth]\nmode = \"token\"\n")
             .unwrap_err();
         assert!(err.to_string().contains("tokens"), "{err}");
-        // oidc: anonymous_read off, an allowlist, and a way in.
-        let err = Config::parse("[store]\nbucket = \"b\"\n[server.auth]\nmode = \"oidc\"\nanonymous_read = false\nallowed_domains = [\"example.com\"]\n").unwrap_err();
+        // oidc: an issuer, anonymous_read off, an allowlist, and a way in.
+        let err = Config::parse("[store]\nbucket = \"b\"\n[server.auth]\nmode = \"oidc\"\nanonymous_read = false\nallowed_domains = [\"example.com\"]\noauth_client_id = \"x\"\noauth_client_secret = \"y\"\nsession_secret = \"0123456789abcdef0123456789abcdef\"\n").unwrap_err();
+        assert!(err.to_string().contains("issuer"), "{err}");
+        let err = Config::parse("[store]\nbucket = \"b\"\n[server.auth]\nmode = \"oidc\"\nissuer = \"https://login.example.com\"\nanonymous_read = false\nallowed_domains = [\"example.com\"]\n").unwrap_err();
         assert!(err.to_string().contains("way in"), "{err}");
-        let err = Config::parse("[store]\nbucket = \"b\"\n[server.auth]\nmode = \"oidc\"\nanonymous_read = false\nallowed_domains = [\"example.com\"]\noauth_client_id = \"x\"\noauth_client_secret = \"y\"\n").unwrap_err();
+        let err = Config::parse("[store]\nbucket = \"b\"\n[server.auth]\nmode = \"oidc\"\nissuer = \"https://login.example.com\"\nanonymous_read = false\nallowed_domains = [\"example.com\"]\noauth_client_id = \"x\"\noauth_client_secret = \"y\"\n").unwrap_err();
         assert!(err.to_string().contains("session_secret"), "{err}");
         let ok = Config::parse("[store]\nbucket = \"b\"\n[server.auth]\nmode = \"oidc\"\nissuer = \"https://login.example.com\"\nanonymous_read = false\nallowed_domains = [\"example.com\"]\noauth_client_id = \"x\"\noauth_client_secret = \"y\"\nsession_secret = \"0123456789abcdef0123456789abcdef\"\n").unwrap();
         assert_eq!(ok.server.auth.issuer, "https://login.example.com");
@@ -1954,6 +1957,11 @@ audiences = ["walgit-cli", "https://git.example.com"]
         )
         .unwrap_err();
         assert!(err.to_string().contains("loopback-only"), "{err}");
+        // The issuer is an oidc-only requirement: none and token mode validate without one.
+        let none = Config::parse("[store]\nbucket = \"b\"\n").unwrap();
+        assert_eq!(none.server.auth.issuer, "");
+        let tok = Config::parse("[store]\nbucket = \"b\"\n[server.auth]\nmode = \"token\"\ntokens = [{ principal = \"ci\", token = \"s\" }]\n").unwrap();
+        assert_eq!(tok.server.auth.issuer, "");
     }
 
     #[test]

--- a/crates/walgit-server/src/auth.rs
+++ b/crates/walgit-server/src/auth.rs
@@ -1084,6 +1084,7 @@ GcZ0izY/30012ajdHY+/QK5lsMoxTnn0skdS+spLxaS5ZEO4qvPVb8RAoCkWMMal
     fn config() -> walgit_config::Config {
         let mut cfg = walgit_config::Config::default();
         cfg.server.auth.mode = AuthMode::Oidc;
+        cfg.server.auth.issuer = ISSUER.into();
         cfg.server.auth.allowed_domains = vec!["Example.com".into()];
         cfg.server.auth.audiences = vec![AUD.into()];
         cfg.server.auth.anonymous_read = false;

--- a/walgit.example.toml
+++ b/walgit.example.toml
@@ -50,7 +50,7 @@ anonymous_read = true             # must be false in oidc mode
 # ]
 # admin_emails = []                # oidc: emails that may delete repos or PUT/DELETE settings and policy.json
 # admin_domains = []               # oidc: email domains that may delete repos or PUT/DELETE settings and policy.json
-# issuer = "https://id.example.com"        # oidc: discovery at <issuer>/.well-known/openid-configuration
+# issuer = "https://id.example.com"        # oidc: required, no default. Discovery at <issuer>/.well-known/openid-configuration
 # allowed_domains = ["example.com"]        # oidc: email domains admitted (email_verified required)
 # allowed_emails = []                      # oidc: individual identities admitted
 # write_domains = ["example.com"]          # oidc: omit to let every admitted identity write


### PR DESCRIPTION
With `mode = "oidc"` and no `issuer` set, the config passes validation and the server quietly uses `https://accounts.google.com`, the default in `AuthConfig::default`. Discovery, the JWKS fetch and every ID token check then run against Google without anyone having asked for it, and `walgit.example.toml` shows the key commented out as if it were optional.

This makes the default empty. The existing check (`server.auth.issuer must be an https URL ...`) then rejects oidc mode until an issuer is named, which is the fail-closed behaviour AGENTS.md section 1.3 asks for. The check only runs in the oidc arm, so `none` and `token` mode are untouched; the test asserts that too, and the example file now says the key is required.

One behaviour change to know about: an oidc host that never set an issuer has been signing people in via Google and will now refuse to start until it names one. The error text says which key.

Checked with the built binary (a minimal oidc config fails without `issuer`, passes with it), `cargo test -p walgit-config` and `cargo test -p walgit-server --lib`; the ID-token fixture in `auth.rs` now sets the issuer it signs with. No browser sign-in against a live issuer was tried.

Same pass as #25, #26, #27, #28, #29.
