### PR TITLE
feat: Add optional external storage plugins with a pass-through example

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ machines whose "disk" is 20 GiB of tmpfs, next to a long tail of small repositor
 | `docs/POLICY.md` | Anyone touching receive-pack authorization or writing a repo policy. Normative rule language. |
 | `docs/LFS.md` | Anyone touching LFS (`lfs.rs`, `lfs_upstream.rs`) or importing a repository whose LFS history lives elsewhere. |
 | `docs/INTEGRITY.md` | Anyone touching import, the maintainer's `fsck`/`repair` units, or seeing `connectivity: missing object` on a push. |
+| `docs/STORAGE_PLUGINS.md` | Anyone writing or operating an external store decorator (`[store.plugin]`), or changing `walgit-store-plugin`. The boundary, decorator obligations and compatibility contract. |
 | `docs/EVENTS.md` | Anyone changing WAL-derived ref events, the webhook bridge, consumer semantics or event cursors. |
 | `docs/CONTRACT.md` | When you touch a crate boundary. The cross-crate contract; *extend, don't rename*; code wins where they differ. |
 | `docs/reference/cursor-git-at-any-scale.md` | The source design, verbatim. Read once before touching WAL/publish/sync/placement. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -402,6 +402,12 @@ decision in §4 — or the PR is; never "fix later".
 
 Decision identifiers are stable; gaps in the numbering are intentional.
 
+- **D42 (2026-09-09)** Optional storage plugins use a versioned C boundary and
+  decorate the one CLI store constructor. Core contains no encryption/provider
+  policy; the example is pass-through. All storage roles share the decorator,
+  failures are fatal, and bucket mounts cannot bypass it. See
+  `docs/STORAGE_PLUGINS.md` for the lifetime and compatibility contract.
+
 ---
 
 ## 5. Working rules

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -402,7 +402,7 @@ decision in §4 — or the PR is; never "fix later".
 
 Decision identifiers are stable; gaps in the numbering are intentional.
 
-- **D42 (2026-09-09)** Optional storage plugins use a versioned C boundary and
+- **D42 (2026-09-09)** Optional storage plugins use a checked `abi_stable` boundary and
   decorate the one CLI store constructor. Core contains no encryption/provider
   policy; the example is pass-through. All storage roles share the decorator,
   failures are fatal, and bucket mounts cannot bypass it. See

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,52 @@
 version = 4
 
 [[package]]
+name = "abi_stable"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d6512d3eb05ffe5004c59c206de7f99c34951504056ce23fc953842f12c445"
+dependencies = [
+ "abi_stable_derive",
+ "abi_stable_shared",
+ "const_panic",
+ "core_extensions",
+ "generational-arena",
+ "libloading",
+ "lock_api",
+ "parking_lot",
+ "paste",
+ "repr_offset",
+ "rustc_version",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "abi_stable_derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7178468b407a4ee10e881bc7a328a65e739f0863615cca4429d43916b05e898"
+dependencies = [
+ "abi_stable_shared",
+ "as_derive_utils",
+ "core_extensions",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 1.0.109",
+ "typed-arena",
+]
+
+[[package]]
+name = "abi_stable_shared"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b5df7688c123e63f4d4d649cba63f2967ba7f7861b1664fca3f77d3dad2b63"
+dependencies = [
+ "core_extensions",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,6 +163,18 @@ name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "as_derive_utils"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff3c96645900a44cf11941c111bd08a6573b0e2f9f69bc9264b179d8fae753c4"
+dependencies = [
+ "core_extensions",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "asn1-rs"
@@ -1075,6 +1133,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
+name = "const_panic"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9603f79528ece8163c496f8932121cb36cfe46259e9c907bb3d8205139d7caa3"
+dependencies = [
+ "typewit",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1099,6 +1166,21 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core_extensions"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42bb5e5d0269fd4f739ea6cedaf29c16d81c27a7ce7582008e90eb50dcd57003"
+dependencies = [
+ "core_extensions_proc_macros",
+]
+
+[[package]]
+name = "core_extensions_proc_macros"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533d38ecd2709b7608fb8e18e4504deb99e9a72879e6aa66373a76d8dc4259ea"
 
 [[package]]
 name = "cpufeatures"
@@ -1707,6 +1789,15 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generational-arena"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877e94aff08e743b651baaea359664321055749b398adff8740a7399af7796e7"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -3517,12 +3608,12 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libloading"
-version = "0.8.9"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
- "windows-link",
+ "winapi",
 ]
 
 [[package]]
@@ -3960,6 +4051,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem"
@@ -4465,6 +4562,15 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "repr_offset"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1070755bd29dffc19d0971cab794e607839ba2ef4b69a9e6fbc8733c1b72ea"
+dependencies = [
+ "tstr",
+]
 
 [[package]]
 name = "reqwest"
@@ -5213,6 +5319,17 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
@@ -5678,10 +5795,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tstr"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f8e0294f14baae476d0dd0a2d780b2e24d66e349a9de876f5126777a37bdba7"
+dependencies = [
+ "tstr_proc_macros",
+]
+
+[[package]]
+name = "tstr_proc_macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78122066b0cb818b8afd08f7ed22f7fdbc3e90815035726f0840d0d26c0747a"
+
+[[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "typewit"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "214ca0b2191785cbc06209b9ca1861e048e39b5ba33574b3cedd58363d5bb5f6"
 
 [[package]]
 name = "uluru"
@@ -6022,6 +6166,7 @@ dependencies = [
 name = "walgit-store-passthrough"
 version = "0.1.0"
 dependencies = [
+ "abi_stable",
  "anyhow",
  "serde_json",
  "walgit-store",
@@ -6032,11 +6177,11 @@ dependencies = [
 name = "walgit-store-plugin"
 version = "0.1.0"
 dependencies = [
+ "abi_stable",
  "anyhow",
  "async-trait",
  "bytes",
  "futures",
- "libloading",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3516,6 +3516,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5839,6 +5849,7 @@ dependencies = [
  "walgit-proto",
  "walgit-server",
  "walgit-store",
+ "walgit-store-plugin",
  "walgit-wal",
 ]
 
@@ -5851,6 +5862,7 @@ dependencies = [
  "cron",
  "humantime-serde",
  "serde",
+ "serde_json",
  "toml",
  "tracing",
 ]
@@ -6004,6 +6016,32 @@ dependencies = [
  "uuid",
  "walgit-config",
  "walgit-proto",
+]
+
+[[package]]
+name = "walgit-store-passthrough"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "serde_json",
+ "walgit-store",
+ "walgit-store-plugin",
+]
+
+[[package]]
+name = "walgit-store-plugin"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "futures",
+ "libloading",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "walgit-store",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@ resolver = "3"
 members = [
     "crates/walgit-proto",
     "crates/walgit-store",
+    "crates/walgit-store-plugin",
+    "examples/store-passthrough",
     "crates/walgit-config",
     "crates/walgit-git",
     "crates/walgit-wal",
@@ -63,6 +65,7 @@ too_many_lines = "allow"
 [workspace.dependencies]
 walgit-proto = { path = "crates/walgit-proto" }
 walgit-store = { path = "crates/walgit-store" }
+walgit-store-plugin = { path = "crates/walgit-store-plugin" }
 walgit-config = { path = "crates/walgit-config" }
 walgit-git = { path = "crates/walgit-git" }
 walgit-wal = { path = "crates/walgit-wal" }

--- a/crates/walgit-cli/Cargo.toml
+++ b/crates/walgit-cli/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/bin/walgit-server.rs"
 [dependencies]
 walgit-proto.workspace = true
 walgit-store.workspace = true
+walgit-store-plugin.workspace = true
 walgit-config.workspace = true
 walgit-git.workspace = true
 walgit-wal.workspace = true

--- a/crates/walgit-cli/src/bundle_cmd.rs
+++ b/crates/walgit-cli/src/bundle_cmd.rs
@@ -6,9 +6,9 @@ use std::sync::Arc;
 use anyhow::{Result, bail};
 use tracing::info;
 
+use crate::open_store;
 use walgit_bundle::Bundler;
 use walgit_config::Config;
-use walgit_store::open_store;
 use walgit_wal::Registry;
 
 use crate::BundleAction;

--- a/crates/walgit-cli/src/compact.rs
+++ b/crates/walgit-cli/src/compact.rs
@@ -7,9 +7,9 @@ use std::sync::Arc;
 use anyhow::{Result, bail};
 use tracing::{info, warn};
 
+use crate::open_store;
 use walgit_config::Config;
 use walgit_server::ops::{CompactRequest, compact_repo};
-use walgit_store::open_store;
 use walgit_wal::Registry;
 
 use crate::cli::parse_repo_id;

--- a/crates/walgit-cli/src/import.rs
+++ b/crates/walgit-cli/src/import.rs
@@ -12,9 +12,9 @@ use std::time::Instant;
 use anyhow::{Context, Result, bail};
 use tracing::info;
 
+use crate::open_store;
 use walgit_config::Config;
 use walgit_git::{IngestOptions, ObjectFormat};
-use walgit_store::open_store;
 use walgit_wal::Registry;
 
 use crate::cli::parse_repo_id;

--- a/crates/walgit-cli/src/import_direct.rs
+++ b/crates/walgit-cli/src/import_direct.rs
@@ -25,6 +25,7 @@ use anyhow::{Context, Result, bail};
 use tracing::info;
 use walgit_proto::prost::Message;
 
+use crate::open_store;
 use walgit_config::Config;
 use walgit_proto::keys;
 use walgit_proto::v1::{
@@ -32,7 +33,7 @@ use walgit_proto::v1::{
 };
 use walgit_proto::{WAL_FORMAT_VERSION, time};
 use walgit_store::{
-    ObjectStore, ObjectStoreExt, Prefixed, PutBody, PutMode, PutOptions, StoreError, open_store,
+    ObjectStore, ObjectStoreExt, Prefixed, PutBody, PutMode, PutOptions, StoreError,
 };
 
 use crate::cli::parse_repo_id;

--- a/crates/walgit-cli/src/lib.rs
+++ b/crates/walgit-cli/src/lib.rs
@@ -44,7 +44,7 @@ mod serve;
 mod wal_cmd;
 
 /// The single store construction path for commands and their background roles.
-/// Decorators see logical keys; open_store applies the global prefix underneath.
+/// Decorators see logical keys; `open_store` applies the global prefix underneath.
 async fn open_store(cfg: &walgit_config::Config) -> Result<walgit_store::DynStore> {
     if let Some(plugin) = &cfg.store.plugin {
         anyhow::ensure!(

--- a/crates/walgit-cli/src/lib.rs
+++ b/crates/walgit-cli/src/lib.rs
@@ -43,6 +43,29 @@ mod repo;
 mod serve;
 mod wal_cmd;
 
+/// The single store construction path for commands and their background roles.
+/// Decorators see logical keys; open_store applies the global prefix underneath.
+async fn open_store(cfg: &walgit_config::Config) -> Result<walgit_store::DynStore> {
+    if let Some(plugin) = &cfg.store.plugin {
+        anyhow::ensure!(
+            plugin.library.is_absolute(),
+            "store.plugin.library must be absolute"
+        );
+        // A bucket mount bypasses ObjectStore and therefore every decorator.
+        anyhow::ensure!(
+            cfg.cache.store_mount.is_none(),
+            "storage plugins cannot use cache.store_mount"
+        );
+    }
+    let store = walgit_store::open_store(cfg).await?;
+    match &cfg.store.plugin {
+        Some(plugin) => {
+            walgit_store_plugin::load(&plugin.library, plugin.options.clone(), store).await
+        }
+        None => Ok(store),
+    }
+}
+
 use std::path::PathBuf;
 
 use anyhow::Result;

--- a/crates/walgit-cli/src/repo.rs
+++ b/crates/walgit-cli/src/repo.rs
@@ -5,9 +5,9 @@ use std::sync::Arc;
 use anyhow::{Result, bail};
 use tracing::info;
 
+use crate::open_store;
 use walgit_config::Config;
 use walgit_git::ObjectFormat;
-use walgit_store::open_store;
 use walgit_wal::Registry;
 
 use crate::cli::{parse_repo_id, println_kv};

--- a/crates/walgit-cli/src/serve.rs
+++ b/crates/walgit-cli/src/serve.rs
@@ -21,9 +21,9 @@ use anyhow::Result;
 use tokio::signal;
 use tracing::{info, warn};
 
+use crate::open_store;
 use walgit_config::{Config, Role};
 use walgit_server::{AppState, serve};
-use walgit_store::open_store;
 
 pub async fn run(cfg: &Arc<Config>) -> Result<()> {
     info!(backend = ?cfg.store.backend, "opening store");

--- a/crates/walgit-cli/src/settings_cmd.rs
+++ b/crates/walgit-cli/src/settings_cmd.rs
@@ -1,9 +1,9 @@
 //! `walgit settings show|set|clear|history <repo>` — D24 per-repo settings.
 use std::sync::Arc;
 
+use crate::open_store;
 use anyhow::{Context, Result};
 use walgit_config::Config;
-use walgit_store::open_store;
 use walgit_wal::Registry;
 
 use crate::SettingsAction;

--- a/crates/walgit-cli/src/wal_cmd.rs
+++ b/crates/walgit-cli/src/wal_cmd.rs
@@ -5,9 +5,9 @@ use std::sync::Arc;
 use anyhow::{Result, bail};
 use tracing::info;
 
+use crate::open_store;
 use walgit_config::Config;
 use walgit_git::ObjectFormat;
-use walgit_store::open_store;
 use walgit_wal::Registry;
 
 use crate::WalAction;

--- a/crates/walgit-config/Cargo.toml
+++ b/crates/walgit-config/Cargo.toml
@@ -9,6 +9,7 @@ tracing.workspace = true
 cron.workspace = true
 anyhow.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 toml.workspace = true
 humantime-serde.workspace = true
 bytesize.workspace = true

--- a/crates/walgit-config/src/lib.rs
+++ b/crates/walgit-config/src/lib.rs
@@ -225,6 +225,8 @@ pub struct StaticToken {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct StoreConfig {
+    /// Optional trusted shared-library decorator, applied to every CLI store.
+    pub plugin: Option<StorePluginConfig>,
     pub backend: StoreBackend,
     pub bucket: String,
     /// Global key prefix inside the bucket (no leading slash; trailing slash added).
@@ -235,6 +237,20 @@ pub struct StoreConfig {
     /// Objects larger than this use resumable/multipart upload.
     pub multipart_threshold: ByteSize,
     pub multipart_part_size: ByteSize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StorePluginConfig {
+    /// Absolute path to an operator-installed cdylib. Never supplied by a client.
+    pub library: PathBuf,
+    /// Plugin-owned configuration; walgit only transports this JSON value.
+    #[serde(default = "empty_plugin_options")]
+    pub options: serde_json::Value,
+}
+
+fn empty_plugin_options() -> serde_json::Value {
+    serde_json::json!({})
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -1070,6 +1086,7 @@ impl Default for AuthConfig {
 impl Default for StoreConfig {
     fn default() -> Self {
         StoreConfig {
+            plugin: None,
             backend: StoreBackend::Gcs,
             bucket: "walgit".into(),
             prefix: String::new(),

--- a/crates/walgit-store-plugin/Cargo.toml
+++ b/crates/walgit-store-plugin/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "walgit-store-plugin"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+# The host owns the backend SDKs. A decorator needs only the store contract.
+walgit-store = { path = "../walgit-store", default-features = false }
+anyhow.workspace = true
+async-trait.workspace = true
+bytes.workspace = true
+futures.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+libloading = "0.8"
+
+[dev-dependencies]
+tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/walgit-store-plugin/Cargo.toml
+++ b/crates/walgit-store-plugin/Cargo.toml
@@ -14,7 +14,7 @@ futures.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
-libloading = "0.8"
+abi_stable = { version = "0.11.3", default-features = false }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/walgit-store-plugin/src/abi.rs
+++ b/crates/walgit-store-plugin/src/abi.rs
@@ -1,162 +1,59 @@
-//! Version 1 C ABI. See `docs/STORAGE_PLUGINS.md` for ownership and threading.
-//! No Rust allocation, trait object, future or panic crosses this boundary.
-#![allow(unsafe_code)]
+//! Checked Rust plugin boundary. Ownership and layouts are provided by `abi_stable`.
+// These allowances apply only to generated ABI glue, not hand-written unsafe code.
+#![allow(
+    unsafe_code,
+    non_local_definitions,
+    clippy::used_underscore_binding,
+    clippy::expl_impl_clone_on_copy
+)]
 
-use std::ffi::c_void;
+use abi_stable::std_types::{RBox, ROption, RResult, RString, RVec};
+use abi_stable::{
+    StableAbi, library::RootModule, package_version_strings, sabi_trait, sabi_types::VersionStrings,
+};
 
-pub const ABI_VERSION: u32 = 1;
 pub const MAX_FRAME: usize = 1024 * 1024;
 pub const MAX_METADATA: usize = 16 * 1024 * 1024;
 
-/// Borrowed for the duration of a call. Null is valid only when len is zero.
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct Slice {
-    pub ptr: *const u8,
-    pub len: usize,
+/// One owned, serially polled byte stream. Dropping it cancels without draining.
+/// The SDK invokes poll off async workers. Errors contain serialized `WireError`.
+#[sabi_trait]
+pub trait StreamApi: Send {
+    #[sabi(last_prefix_field)]
+    fn poll(&mut self) -> RResult<ROption<RVec<u8>>, RString>;
 }
-
-impl From<&[u8]> for Slice {
-    fn from(bytes: &[u8]) -> Self {
-        Self {
-            ptr: bytes.as_ptr(),
-            len: bytes.len(),
-        }
-    }
-}
-
-/// Owned bytes. The receiver calls this allocation's release function once.
-#[repr(C)]
-pub struct Buffer {
-    pub ptr: *mut u8,
-    pub len: usize,
-    pub release: Option<unsafe extern "C" fn(*mut u8, usize)>,
-}
-
-impl Default for Buffer {
-    fn default() -> Self {
-        Self {
-            ptr: std::ptr::null_mut(),
-            len: 0,
-            release: None,
-        }
-    }
-}
-
-/// Owned, pull-based stream. next: 0 = EOF, 1 = bytes, -1 = JSON `WireError`.
-/// next is serialized per stream; distinct streams may be called concurrently.
-/// release must cancel/drop the stream and never consume its remaining bytes.
-#[repr(C)]
-pub struct Stream {
-    pub context: *mut c_void,
-    pub next: Option<unsafe extern "C" fn(*mut c_void, *mut Buffer) -> i32>,
-    pub release: Option<unsafe extern "C" fn(*mut c_void)>,
-}
-
-impl Default for Stream {
-    fn default() -> Self {
-        Self {
-            context: std::ptr::null_mut(),
-            next: None,
-            release: None,
-        }
-    }
-}
+pub type Stream = ROption<StreamApi_TO<'static, RBox<()>>>;
 
 #[repr(C)]
-pub struct Request {
-    pub metadata: Slice,
-    /// Ownership transfers to `request()`,  even when the operation fails.
-    pub body: Stream,
-}
-
-#[repr(C)]
-#[derive(Default)]
+#[derive(StableAbi, Default)]
 pub struct Reply {
-    /// 0 = success; -1 = metadata contains `WireError`. Other values are invalid.
-    pub status: i32,
-    pub metadata: Buffer,
+    pub metadata: RVec<u8>,
     pub body: Stream,
 }
 
-/// An owned object-store endpoint. `request()` is concurrent and synchronous;
-/// callers must run it off their async executor. release follows all calls and
-/// all response streams. Every function must contain its own panic boundary.
-#[repr(C)]
-pub struct Store {
-    pub context: *mut c_void,
-    pub request: unsafe extern "C" fn(*mut c_void, Request, *mut Reply),
-    pub release: unsafe extern "C" fn(*mut c_void),
-    pub supports_compose: u8,
-    pub compose_is_native: u8,
+/// A concurrent endpoint, kept alive until its calls and response streams end.
+/// Methods are synchronous; the SDK handles blocking dispatch and panic errors.
+#[sabi_trait]
+pub trait StoreApi: Send + Sync {
+    fn request(&self, metadata: RVec<u8>, body: Stream) -> RResult<Reply, RString>;
+    fn supports_compose(&self) -> bool;
+    #[sabi(last_prefix_field)]
+    fn compose_is_native(&self) -> bool;
 }
+pub type Store = StoreApi_TO<'static, RBox<()>>;
 
 #[repr(C)]
-pub struct PluginHeader {
-    pub abi_version: u32,
-    pub struct_size: u32,
-}
-
-#[repr(C)]
+#[derive(StableAbi)]
+#[sabi(kind(Prefix(prefix_ref = PluginRef)))]
 pub struct Plugin {
-    pub abi_version: u32,
-    pub struct_size: u32,
-    /// Consumes inner on success AND failure. Config is borrowed JSON.
-    /// On success writes out; on failure writes error and leaves out untouched.
-    pub create: unsafe extern "C" fn(Store, Slice, *mut Store, *mut Buffer) -> i32,
+    /// Consumes the inner endpoint on success and failure. Options are JSON.
+    #[sabi(last_prefix_field)]
+    pub create: extern "C" fn(Store, RVec<u8>) -> RResult<Store, RString>,
 }
 
-// SAFETY: V1 endpoints must support concurrent calls; their opaque context is
-// never dereferenced by callers. Stream ownership enforces serialized polling.
-unsafe impl Send for Store {}
-// SAFETY: Same concurrent request contract as Send.
-unsafe impl Sync for Store {}
-// SAFETY: Stream handles transfer ownership; each handle is polled serially.
-unsafe impl Send for Stream {}
-// SAFETY: Owned buffer and its release function may move together across threads.
-unsafe impl Send for Buffer {}
-
-/// # Safety
-/// The caller guarantees the slice addresses len readable bytes for this call.
-pub unsafe fn read_slice<'a>(slice: Slice, max: usize) -> anyhow::Result<&'a [u8]> {
-    anyhow::ensure!(slice.len <= max, "plugin message exceeds limit");
-    if slice.len == 0 {
-        return Ok(&[]);
-    }
-    anyhow::ensure!(!slice.ptr.is_null(), "null plugin message");
-    // SAFETY: Required readable range is the caller's V1 contract.
-    Ok(unsafe { std::slice::from_raw_parts(slice.ptr, slice.len) })
-}
-
-unsafe extern "C" fn release_buffer(ptr: *mut u8, len: usize) {
-    // SAFETY: Only called once for the boxed slice produced by own_buffer.
-    drop(unsafe { Box::from_raw(std::ptr::slice_from_raw_parts_mut(ptr, len)) });
-}
-
-pub fn own_buffer(bytes: Vec<u8>) -> Buffer {
-    let bytes = bytes.into_boxed_slice();
-    let len = bytes.len();
-    Buffer {
-        ptr: Box::into_raw(bytes).cast(),
-        len,
-        release: Some(release_buffer),
-    }
-}
-
-impl Drop for Buffer {
-    fn drop(&mut self) {
-        if let Some(release) = self.release.take() {
-            // SAFETY: Buffer owns its allocation and uses its allocating module.
-            unsafe { release(self.ptr, self.len) };
-        }
-    }
-}
-
-impl Drop for Stream {
-    fn drop(&mut self) {
-        if let Some(release) = self.release.take() {
-            // SAFETY: This handle owns its context; no poll overlaps drop.
-            unsafe { release(self.context) };
-        }
-    }
+impl RootModule for PluginRef {
+    abi_stable::declare_root_module_statics! {PluginRef}
+    const BASE_NAME: &'static str = "walgit_store_plugin";
+    const NAME: &'static str = "walgit_store_plugin";
+    const VERSION_STRINGS: VersionStrings = package_version_strings!();
 }

--- a/crates/walgit-store-plugin/src/abi.rs
+++ b/crates/walgit-store-plugin/src/abi.rs
@@ -1,0 +1,162 @@
+//! Version 1 C ABI. See `docs/STORAGE_PLUGINS.md` for ownership and threading.
+//! No Rust allocation, trait object, future or panic crosses this boundary.
+#![allow(unsafe_code)]
+
+use std::ffi::c_void;
+
+pub const ABI_VERSION: u32 = 1;
+pub const MAX_FRAME: usize = 1024 * 1024;
+pub const MAX_METADATA: usize = 16 * 1024 * 1024;
+
+/// Borrowed for the duration of a call. Null is valid only when len is zero.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct Slice {
+    pub ptr: *const u8,
+    pub len: usize,
+}
+
+impl From<&[u8]> for Slice {
+    fn from(bytes: &[u8]) -> Self {
+        Self {
+            ptr: bytes.as_ptr(),
+            len: bytes.len(),
+        }
+    }
+}
+
+/// Owned bytes. The receiver calls this allocation's release function once.
+#[repr(C)]
+pub struct Buffer {
+    pub ptr: *mut u8,
+    pub len: usize,
+    pub release: Option<unsafe extern "C" fn(*mut u8, usize)>,
+}
+
+impl Default for Buffer {
+    fn default() -> Self {
+        Self {
+            ptr: std::ptr::null_mut(),
+            len: 0,
+            release: None,
+        }
+    }
+}
+
+/// Owned, pull-based stream. next: 0 = EOF, 1 = bytes, -1 = JSON `WireError`.
+/// next is serialized per stream; distinct streams may be called concurrently.
+/// release must cancel/drop the stream and never consume its remaining bytes.
+#[repr(C)]
+pub struct Stream {
+    pub context: *mut c_void,
+    pub next: Option<unsafe extern "C" fn(*mut c_void, *mut Buffer) -> i32>,
+    pub release: Option<unsafe extern "C" fn(*mut c_void)>,
+}
+
+impl Default for Stream {
+    fn default() -> Self {
+        Self {
+            context: std::ptr::null_mut(),
+            next: None,
+            release: None,
+        }
+    }
+}
+
+#[repr(C)]
+pub struct Request {
+    pub metadata: Slice,
+    /// Ownership transfers to `request()`,  even when the operation fails.
+    pub body: Stream,
+}
+
+#[repr(C)]
+#[derive(Default)]
+pub struct Reply {
+    /// 0 = success; -1 = metadata contains `WireError`. Other values are invalid.
+    pub status: i32,
+    pub metadata: Buffer,
+    pub body: Stream,
+}
+
+/// An owned object-store endpoint. `request()` is concurrent and synchronous;
+/// callers must run it off their async executor. release follows all calls and
+/// all response streams. Every function must contain its own panic boundary.
+#[repr(C)]
+pub struct Store {
+    pub context: *mut c_void,
+    pub request: unsafe extern "C" fn(*mut c_void, Request, *mut Reply),
+    pub release: unsafe extern "C" fn(*mut c_void),
+    pub supports_compose: u8,
+    pub compose_is_native: u8,
+}
+
+#[repr(C)]
+pub struct PluginHeader {
+    pub abi_version: u32,
+    pub struct_size: u32,
+}
+
+#[repr(C)]
+pub struct Plugin {
+    pub abi_version: u32,
+    pub struct_size: u32,
+    /// Consumes inner on success AND failure. Config is borrowed JSON.
+    /// On success writes out; on failure writes error and leaves out untouched.
+    pub create: unsafe extern "C" fn(Store, Slice, *mut Store, *mut Buffer) -> i32,
+}
+
+// SAFETY: V1 endpoints must support concurrent calls; their opaque context is
+// never dereferenced by callers. Stream ownership enforces serialized polling.
+unsafe impl Send for Store {}
+// SAFETY: Same concurrent request contract as Send.
+unsafe impl Sync for Store {}
+// SAFETY: Stream handles transfer ownership; each handle is polled serially.
+unsafe impl Send for Stream {}
+// SAFETY: Owned buffer and its release function may move together across threads.
+unsafe impl Send for Buffer {}
+
+/// # Safety
+/// The caller guarantees the slice addresses len readable bytes for this call.
+pub unsafe fn read_slice<'a>(slice: Slice, max: usize) -> anyhow::Result<&'a [u8]> {
+    anyhow::ensure!(slice.len <= max, "plugin message exceeds limit");
+    if slice.len == 0 {
+        return Ok(&[]);
+    }
+    anyhow::ensure!(!slice.ptr.is_null(), "null plugin message");
+    // SAFETY: Required readable range is the caller's V1 contract.
+    Ok(unsafe { std::slice::from_raw_parts(slice.ptr, slice.len) })
+}
+
+unsafe extern "C" fn release_buffer(ptr: *mut u8, len: usize) {
+    // SAFETY: Only called once for the boxed slice produced by own_buffer.
+    drop(unsafe { Box::from_raw(std::ptr::slice_from_raw_parts_mut(ptr, len)) });
+}
+
+pub fn own_buffer(bytes: Vec<u8>) -> Buffer {
+    let bytes = bytes.into_boxed_slice();
+    let len = bytes.len();
+    Buffer {
+        ptr: Box::into_raw(bytes).cast(),
+        len,
+        release: Some(release_buffer),
+    }
+}
+
+impl Drop for Buffer {
+    fn drop(&mut self) {
+        if let Some(release) = self.release.take() {
+            // SAFETY: Buffer owns its allocation and uses its allocating module.
+            unsafe { release(self.ptr, self.len) };
+        }
+    }
+}
+
+impl Drop for Stream {
+    fn drop(&mut self) {
+        if let Some(release) = self.release.take() {
+            // SAFETY: This handle owns its context; no poll overlaps drop.
+            unsafe { release(self.context) };
+        }
+    }
+}

--- a/crates/walgit-store-plugin/src/bridge.rs
+++ b/crates/walgit-store-plugin/src/bridge.rs
@@ -1,10 +1,9 @@
-#![allow(unsafe_code)]
-
-use std::ffi::c_void;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::Arc;
 use std::time::Duration;
 
+use abi_stable::sabi_trait::TD_Opaque;
+use abi_stable::std_types::{ROption, RResult, RString, RVec};
 use bytes::Bytes;
 use futures::{StreamExt, TryStreamExt};
 use serde::Serialize;
@@ -14,59 +13,30 @@ use walgit_store::{
     PutBody, PutOptions, Result, StoreError, Version,
 };
 
-use crate::abi::{self, Buffer, Reply, Request, Slice};
+use crate::abi::{self, Reply, StoreApi, StreamApi};
 use crate::wire::{Accel, Meta, Operation, ReadResult, WireError, put_options};
 
-fn json(value: &impl Serialize) -> Result<Buffer> {
+fn json(value: &impl Serialize) -> Result<RVec<u8>> {
     let bytes = serde_json::to_vec(value).map_err(StoreError::other)?;
     if bytes.len() > abi::MAX_METADATA {
         return Err(StoreError::InvalidArgument(
             "plugin metadata exceeds limit".into(),
         ));
     }
-    Ok(abi::own_buffer(bytes))
+    Ok(bytes.into())
 }
-
-fn error_reply(error: StoreError) -> Reply {
-    let error = WireError::from(error);
-    let bytes = serde_json::to_vec(&error)
-        .unwrap_or_else(|_| br#"{"error":"other","message":"plugin failure"}"#.to_vec());
-    Reply {
-        status: -1,
-        metadata: abi::own_buffer(bytes),
-        body: abi::Stream::default(),
-    }
+fn wire_error(error: StoreError) -> RString {
+    serde_json::to_string(&WireError::from(error))
+        .unwrap_or_else(|_| r#"{"error":"other","message":"plugin failure"}"#.into())
+        .into()
 }
-
-pub fn error_text(buffer: &Buffer) -> String {
-    // SAFETY: A live V1 buffer owns len readable bytes until it is dropped.
-    match unsafe {
-        abi::read_slice(
-            Slice {
-                ptr: buffer.ptr,
-                len: buffer.len,
-            },
-            abi::MAX_METADATA,
-        )
-    } {
-        Ok(bytes) => String::from_utf8_lossy(bytes).into_owned(),
-        Err(_) => "invalid error response".into(),
+fn decode<T: serde::de::DeserializeOwned>(buffer: &[u8]) -> Result<T> {
+    if buffer.len() > abi::MAX_METADATA {
+        return Err(StoreError::InvalidArgument(
+            "plugin metadata exceeds limit".into(),
+        ));
     }
-}
-
-fn decode<T: serde::de::DeserializeOwned>(buffer: &Buffer) -> Result<T> {
-    // SAFETY: A live V1 buffer owns len readable bytes until drop.
-    let bytes = unsafe {
-        abi::read_slice(
-            Slice {
-                ptr: buffer.ptr,
-                len: buffer.len,
-            },
-            abi::MAX_METADATA,
-        )
-    }
-    .map_err(StoreError::other)?;
-    serde_json::from_slice(bytes).map_err(StoreError::other)
+    serde_json::from_slice(buffer).map_err(StoreError::other)
 }
 
 struct StreamState {
@@ -74,96 +44,63 @@ struct StreamState {
     pending: Bytes,
     runtime: Handle,
 }
-
+impl StreamApi for StreamState {
+    fn poll(&mut self) -> RResult<ROption<RVec<u8>>, RString> {
+        match catch_unwind(AssertUnwindSafe(|| {
+            if self.pending.is_empty() {
+                match self.runtime.block_on(self.body.next()) {
+                    Some(Ok(bytes)) => self.pending = bytes,
+                    Some(Err(error)) => return Err(error),
+                    None => return Ok(ROption::RNone),
+                }
+            }
+            let size = self.pending.len().min(abi::MAX_FRAME);
+            Ok(ROption::RSome(self.pending.split_to(size).to_vec().into()))
+        })) {
+            Ok(result) => result.map_err(wire_error).into(),
+            Err(_) => RResult::RErr(wire_error(StoreError::other(anyhow::anyhow!(
+                "plugin stream panicked"
+            )))),
+        }
+    }
+}
 fn expose_stream(body: ByteStream, runtime: Handle) -> abi::Stream {
-    abi::Stream {
-        context: Box::into_raw(Box::new(StreamState {
+    ROption::RSome(abi::StreamApi_TO::from_value(
+        StreamState {
             body,
             pending: Bytes::new(),
             runtime,
-        }))
-        .cast(),
-        next: Some(next_stream),
-        release: Some(release_stream),
-    }
+        },
+        TD_Opaque,
+    ))
 }
 
-unsafe extern "C" fn next_stream(context: *mut c_void, out: *mut Buffer) -> i32 {
-    let result = catch_unwind(AssertUnwindSafe(|| {
-        // SAFETY: Context was allocated in expose_stream; polling is exclusive.
-        let state = unsafe { &mut *context.cast::<StreamState>() };
-        if state.pending.is_empty() {
-            match state.runtime.block_on(state.body.next()) {
-                Some(Ok(bytes)) => state.pending = bytes,
-                Some(Err(e)) => return Err(e),
-                None => return Ok(None),
-            }
-        }
-        let size = state.pending.len().min(abi::MAX_FRAME);
-        Ok(Some(state.pending.split_to(size).to_vec()))
-    }));
-    let (code, buffer) = match result {
-        Ok(Ok(Some(bytes))) => (1, abi::own_buffer(bytes)),
-        Ok(Ok(None)) => (0, Buffer::default()),
-        Ok(Err(e)) => (-1, error_reply(e).metadata),
-        Err(_) => (
-            -1,
-            error_reply(StoreError::other(anyhow::anyhow!("plugin stream panicked"))).metadata,
-        ),
-    };
-    // SAFETY: V1 caller supplies a writable, uninitialized output Buffer.
-    unsafe { out.write(buffer) };
-    code
-}
-
-unsafe extern "C" fn release_stream(context: *mut c_void) {
-    let _ = catch_unwind(AssertUnwindSafe(|| {
-        // SAFETY: Stream handle owns this allocation, with no poll in flight.
-        drop(unsafe { Box::from_raw(context.cast::<StreamState>()) });
-    }));
-}
-
-struct Endpoint(abi::Store);
-impl Drop for Endpoint {
-    fn drop(&mut self) {
-        // SAFETY: Arc guarantees no calls or streams using the endpoint remain.
-        unsafe { (self.0.release)(self.0.context) };
-    }
-}
-
-// Holding endpoint keeps the producing store/runtime alive until stream release.
-fn receive_stream(stream: abi::Stream, endpoint: Option<Arc<Endpoint>>) -> ByteStream {
+// RVec keeps its allocator's checked destruction machinery. Bytes holds that
+// owner without copying the returned frame into a second Rust allocation.
+fn receive_stream(stream: abi::Stream, endpoint: Option<Arc<abi::Store>>) -> ByteStream {
     Box::pin(futures::stream::try_unfold(
         (stream, endpoint),
         |(stream, endpoint)| async move {
             tokio::task::spawn_blocking(move || {
-                let Some(next) = stream.next else {
+                let Some(mut stream) = stream.into_option() else {
                     return Ok(None);
                 };
-                let mut buffer = Buffer::default();
-                // SAFETY: The stream is owned, polled serially, and out is writable.
-                let code = unsafe { next(stream.context, &raw mut buffer) };
-                match code {
-                    0 => Ok(None),
-                    1 => {
-                        // SAFETY: The returned buffer lives through this copy.
-                        let bytes = unsafe {
-                            abi::read_slice(
-                                Slice {
-                                    ptr: buffer.ptr,
-                                    len: buffer.len,
-                                },
-                                abi::MAX_FRAME,
-                            )
-                        }
-                        .map_err(StoreError::other)?;
-                        Ok(Some((Bytes::copy_from_slice(bytes), (stream, endpoint))))
-                    }
-                    -1 => Err(StoreError::from(decode::<WireError>(&buffer)?)),
-                    _ => Err(StoreError::other(anyhow::anyhow!(
-                        "invalid plugin stream status"
-                    ))),
+                let frame = stream.poll().into_result().map_err(|error| {
+                    decode::<WireError>(error.as_bytes())
+                        .map_or_else(std::convert::identity, StoreError::from)
+                })?;
+                let Some(frame) = frame.into_option() else {
+                    return Ok(None);
+                };
+                if frame.len() > abi::MAX_FRAME {
+                    return Err(StoreError::InvalidArgument(
+                        "plugin frame exceeds limit".into(),
+                    ));
                 }
+                Ok(Some((
+                    Bytes::from_owner(frame),
+                    (ROption::RSome(stream), endpoint),
+                )))
             })
             .await
             .map_err(StoreError::other)?
@@ -183,50 +120,34 @@ impl Drop for StoreState {
         }
     }
 }
-
+impl StoreApi for StoreState {
+    fn request(&self, metadata: RVec<u8>, body: abi::Stream) -> RResult<Reply, RString> {
+        match catch_unwind(AssertUnwindSafe(|| {
+            let operation: Operation = decode(&metadata)?;
+            self.runtime.block_on(dispatch(self, operation, body))
+        })) {
+            Ok(result) => result.map_err(wire_error).into(),
+            Err(_) => RResult::RErr(wire_error(StoreError::other(anyhow::anyhow!(
+                "storage plugin panicked"
+            )))),
+        }
+    }
+    fn supports_compose(&self) -> bool {
+        catch_unwind(AssertUnwindSafe(|| self.store.supports_compose())).unwrap_or(false)
+    }
+    fn compose_is_native(&self) -> bool {
+        catch_unwind(AssertUnwindSafe(|| self.store.compose_is_native())).unwrap_or(false)
+    }
+}
 pub fn expose(store: DynStore, runtime: Handle, owned_runtime: Option<Runtime>) -> abi::Store {
-    abi::Store {
-        supports_compose: u8::from(store.supports_compose()),
-        compose_is_native: u8::from(store.compose_is_native()),
-        context: Box::into_raw(Box::new(StoreState {
+    abi::StoreApi_TO::from_value(
+        StoreState {
             store,
             runtime,
             owned_runtime,
-        }))
-        .cast(),
-        request: request_store,
-        release: release_store,
-    }
-}
-
-unsafe extern "C" fn request_store(context: *mut c_void, request: Request, out: *mut Reply) {
-    let result = catch_unwind(AssertUnwindSafe(|| {
-        // SAFETY: Context is a live StoreState; its fields support concurrent use.
-        let state = unsafe { &*context.cast::<StoreState>() };
-        // SAFETY: Request metadata is borrowed for this synchronous call.
-        let bytes = unsafe { abi::read_slice(request.metadata, abi::MAX_METADATA) }
-            .map_err(StoreError::other)?;
-        let operation: Operation = serde_json::from_slice(bytes).map_err(StoreError::other)?;
-        state
-            .runtime
-            .block_on(dispatch(state, operation, request.body))
-    }));
-    let reply = match result {
-        Ok(Ok(reply)) => reply,
-        Ok(Err(error)) => error_reply(error),
-        Err(_) => error_reply(StoreError::other(anyhow::anyhow!(
-            "storage plugin panicked"
-        ))),
-    };
-    // SAFETY: V1 caller supplies an uninitialized writable Reply.
-    unsafe { out.write(reply) };
-}
-
-unsafe extern "C" fn release_store(context: *mut c_void) {
-    let _ = catch_unwind(AssertUnwindSafe(|| {
-        // SAFETY: Endpoint ownership releases this allocation exactly once.
-        drop(unsafe { Box::from_raw(context.cast::<StoreState>()) });
-    }));
+        },
+        TD_Opaque,
+    )
 }
 
 async fn dispatch(state: &StoreState, operation: Operation, body: abi::Stream) -> Result<Reply> {
@@ -313,41 +234,28 @@ async fn dispatch(state: &StoreState, operation: Operation, body: abi::Stream) -
 
 #[derive(Clone)]
 pub struct RemoteStore {
-    endpoint: Arc<Endpoint>,
+    endpoint: Arc<abi::Store>,
 }
 impl RemoteStore {
     pub fn new(store: abi::Store) -> Self {
         Self {
-            endpoint: Arc::new(Endpoint(store)),
+            endpoint: Arc::new(store),
         }
     }
-
     async fn call(&self, operation: Operation, body: Option<ByteStream>) -> Result<Reply> {
-        let metadata = serde_json::to_vec(&operation).map_err(StoreError::other)?;
-        if metadata.len() > abi::MAX_METADATA {
-            return Err(StoreError::InvalidArgument(
-                "plugin metadata exceeds limit".into(),
-            ));
-        }
+        let metadata = json(&operation)?;
         let body = body.map_or_else(abi::Stream::default, |body| {
             expose_stream(body, Handle::current())
         });
         let endpoint = self.endpoint.clone();
         tokio::task::spawn_blocking(move || {
-            let mut reply = Reply::default();
-            let request = Request {
-                metadata: metadata.as_slice().into(),
-                body,
-            };
-            // SAFETY: Endpoint lives through the call; request transfers body.
-            unsafe { (endpoint.0.request)(endpoint.0.context, request, &raw mut reply) };
-            match reply.status {
-                0 => Ok(reply),
-                -1 => Err(StoreError::from(decode::<WireError>(&reply.metadata)?)),
-                _ => Err(StoreError::other(anyhow::anyhow!(
-                    "invalid storage plugin status"
-                ))),
-            }
+            endpoint
+                .request(metadata, body)
+                .into_result()
+                .map_err(|error| {
+                    decode::<WireError>(error.as_bytes())
+                        .map_or_else(std::convert::identity, StoreError::from)
+                })
         })
         .await
         .map_err(StoreError::other)?
@@ -502,10 +410,10 @@ impl ObjectStore for RemoteStore {
             })
     }
     fn supports_compose(&self) -> bool {
-        self.endpoint.0.supports_compose == 1
+        self.endpoint.supports_compose()
     }
     fn compose_is_native(&self) -> bool {
-        self.endpoint.0.compose_is_native == 1
+        self.endpoint.compose_is_native()
     }
     async fn compose(
         &self,
@@ -529,25 +437,21 @@ impl ObjectStore for RemoteStore {
     }
 }
 
-/// Implementation behind `export_plugin!`. All panics stop at this C boundary.
-/// # Safety
-/// V1 create owns inner and must receive valid borrowed config and writable out/error.
-pub unsafe fn export<F, Fut>(
+/// The SDK factory boundary contains panics; no application future crosses FFI.
+pub fn export<F, Fut>(
     inner: abi::Store,
-    config: Slice,
-    out: *mut abi::Store,
-    error: *mut Buffer,
+    config: RVec<u8>,
     factory: F,
-) -> i32
+) -> RResult<abi::Store, RString>
 where
     F: FnOnce(DynStore, serde_json::Value) -> Fut,
     Fut: Future<Output = anyhow::Result<DynStore>>,
 {
-    let inner: DynStore = Arc::new(RemoteStore::new(inner));
     let result = catch_unwind(AssertUnwindSafe(|| {
-        // SAFETY: V1 caller holds config readable until create returns.
-        let bytes = unsafe { abi::read_slice(config, abi::MAX_METADATA) }?;
-        let config = serde_json::from_slice(bytes)?;
+        let inner: DynStore = Arc::new(RemoteStore::new(inner));
+        let options = decode(&config);
+        drop(config);
+        let config = options?;
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .worker_threads(2)
             .enable_all()
@@ -556,19 +460,7 @@ where
         Ok::<_, anyhow::Error>(expose(store, runtime.handle().clone(), Some(runtime)))
     }));
     match result {
-        Ok(Ok(store)) => {
-            // SAFETY: Success initializes caller's store output exactly once.
-            unsafe { out.write(store) };
-            0
-        }
-        error_result => {
-            let message = match error_result {
-                Ok(Err(e)) => e.to_string(),
-                _ => "storage plugin initialization panicked".into(),
-            };
-            // SAFETY: Failure initializes caller's error output exactly once.
-            unsafe { error.write(abi::own_buffer(message.into_bytes())) };
-            -1
-        }
+        Ok(result) => result.map_err(|e| RString::from(e.to_string())).into(),
+        Err(_) => RResult::RErr("storage plugin initialization panicked".into()),
     }
 }

--- a/crates/walgit-store-plugin/src/bridge.rs
+++ b/crates/walgit-store-plugin/src/bridge.rs
@@ -1,0 +1,574 @@
+#![allow(unsafe_code)]
+
+use std::ffi::c_void;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use futures::{StreamExt, TryStreamExt};
+use serde::Serialize;
+use tokio::runtime::{Handle, Runtime};
+use walgit_store::{
+    AccelTarget, BoxStream, ByteStream, DynStore, GetOptions, GetResult, ObjectMeta, ObjectStore,
+    PutBody, PutOptions, Result, StoreError, Version,
+};
+
+use crate::abi::{self, Buffer, Reply, Request, Slice};
+use crate::wire::{Accel, Meta, Operation, ReadResult, WireError, put_options};
+
+fn json(value: &impl Serialize) -> Result<Buffer> {
+    let bytes = serde_json::to_vec(value).map_err(StoreError::other)?;
+    if bytes.len() > abi::MAX_METADATA {
+        return Err(StoreError::InvalidArgument(
+            "plugin metadata exceeds limit".into(),
+        ));
+    }
+    Ok(abi::own_buffer(bytes))
+}
+
+fn error_reply(error: StoreError) -> Reply {
+    let error = WireError::from(error);
+    let bytes = serde_json::to_vec(&error)
+        .unwrap_or_else(|_| br#"{"error":"other","message":"plugin failure"}"#.to_vec());
+    Reply {
+        status: -1,
+        metadata: abi::own_buffer(bytes),
+        body: abi::Stream::default(),
+    }
+}
+
+pub fn error_text(buffer: &Buffer) -> String {
+    // SAFETY: A live V1 buffer owns len readable bytes until it is dropped.
+    match unsafe {
+        abi::read_slice(
+            Slice {
+                ptr: buffer.ptr,
+                len: buffer.len,
+            },
+            abi::MAX_METADATA,
+        )
+    } {
+        Ok(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+        Err(_) => "invalid error response".into(),
+    }
+}
+
+fn decode<T: serde::de::DeserializeOwned>(buffer: &Buffer) -> Result<T> {
+    // SAFETY: A live V1 buffer owns len readable bytes until drop.
+    let bytes = unsafe {
+        abi::read_slice(
+            Slice {
+                ptr: buffer.ptr,
+                len: buffer.len,
+            },
+            abi::MAX_METADATA,
+        )
+    }
+    .map_err(StoreError::other)?;
+    serde_json::from_slice(bytes).map_err(StoreError::other)
+}
+
+struct StreamState {
+    body: ByteStream,
+    pending: Bytes,
+    runtime: Handle,
+}
+
+fn expose_stream(body: ByteStream, runtime: Handle) -> abi::Stream {
+    abi::Stream {
+        context: Box::into_raw(Box::new(StreamState {
+            body,
+            pending: Bytes::new(),
+            runtime,
+        }))
+        .cast(),
+        next: Some(next_stream),
+        release: Some(release_stream),
+    }
+}
+
+unsafe extern "C" fn next_stream(context: *mut c_void, out: *mut Buffer) -> i32 {
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        // SAFETY: Context was allocated in expose_stream; polling is exclusive.
+        let state = unsafe { &mut *context.cast::<StreamState>() };
+        if state.pending.is_empty() {
+            match state.runtime.block_on(state.body.next()) {
+                Some(Ok(bytes)) => state.pending = bytes,
+                Some(Err(e)) => return Err(e),
+                None => return Ok(None),
+            }
+        }
+        let size = state.pending.len().min(abi::MAX_FRAME);
+        Ok(Some(state.pending.split_to(size).to_vec()))
+    }));
+    let (code, buffer) = match result {
+        Ok(Ok(Some(bytes))) => (1, abi::own_buffer(bytes)),
+        Ok(Ok(None)) => (0, Buffer::default()),
+        Ok(Err(e)) => (-1, error_reply(e).metadata),
+        Err(_) => (
+            -1,
+            error_reply(StoreError::other(anyhow::anyhow!("plugin stream panicked"))).metadata,
+        ),
+    };
+    // SAFETY: V1 caller supplies a writable, uninitialized output Buffer.
+    unsafe { out.write(buffer) };
+    code
+}
+
+unsafe extern "C" fn release_stream(context: *mut c_void) {
+    let _ = catch_unwind(AssertUnwindSafe(|| {
+        // SAFETY: Stream handle owns this allocation, with no poll in flight.
+        drop(unsafe { Box::from_raw(context.cast::<StreamState>()) });
+    }));
+}
+
+struct Endpoint(abi::Store);
+impl Drop for Endpoint {
+    fn drop(&mut self) {
+        // SAFETY: Arc guarantees no calls or streams using the endpoint remain.
+        unsafe { (self.0.release)(self.0.context) };
+    }
+}
+
+// Holding endpoint keeps the producing store/runtime alive until stream release.
+fn receive_stream(stream: abi::Stream, endpoint: Option<Arc<Endpoint>>) -> ByteStream {
+    Box::pin(futures::stream::try_unfold(
+        (stream, endpoint),
+        |(stream, endpoint)| async move {
+            tokio::task::spawn_blocking(move || {
+                let Some(next) = stream.next else {
+                    return Ok(None);
+                };
+                let mut buffer = Buffer::default();
+                // SAFETY: The stream is owned, polled serially, and out is writable.
+                let code = unsafe { next(stream.context, &raw mut buffer) };
+                match code {
+                    0 => Ok(None),
+                    1 => {
+                        // SAFETY: The returned buffer lives through this copy.
+                        let bytes = unsafe {
+                            abi::read_slice(
+                                Slice {
+                                    ptr: buffer.ptr,
+                                    len: buffer.len,
+                                },
+                                abi::MAX_FRAME,
+                            )
+                        }
+                        .map_err(StoreError::other)?;
+                        Ok(Some((Bytes::copy_from_slice(bytes), (stream, endpoint))))
+                    }
+                    -1 => Err(StoreError::from(decode::<WireError>(&buffer)?)),
+                    _ => Err(StoreError::other(anyhow::anyhow!(
+                        "invalid plugin stream status"
+                    ))),
+                }
+            })
+            .await
+            .map_err(StoreError::other)?
+        },
+    ))
+}
+
+struct StoreState {
+    store: DynStore,
+    runtime: Handle,
+    owned_runtime: Option<Runtime>,
+}
+impl Drop for StoreState {
+    fn drop(&mut self) {
+        if let Some(runtime) = self.owned_runtime.take() {
+            runtime.shutdown_background();
+        }
+    }
+}
+
+pub fn expose(store: DynStore, runtime: Handle, owned_runtime: Option<Runtime>) -> abi::Store {
+    abi::Store {
+        supports_compose: u8::from(store.supports_compose()),
+        compose_is_native: u8::from(store.compose_is_native()),
+        context: Box::into_raw(Box::new(StoreState {
+            store,
+            runtime,
+            owned_runtime,
+        }))
+        .cast(),
+        request: request_store,
+        release: release_store,
+    }
+}
+
+unsafe extern "C" fn request_store(context: *mut c_void, request: Request, out: *mut Reply) {
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        // SAFETY: Context is a live StoreState; its fields support concurrent use.
+        let state = unsafe { &*context.cast::<StoreState>() };
+        // SAFETY: Request metadata is borrowed for this synchronous call.
+        let bytes = unsafe { abi::read_slice(request.metadata, abi::MAX_METADATA) }
+            .map_err(StoreError::other)?;
+        let operation: Operation = serde_json::from_slice(bytes).map_err(StoreError::other)?;
+        state
+            .runtime
+            .block_on(dispatch(state, operation, request.body))
+    }));
+    let reply = match result {
+        Ok(Ok(reply)) => reply,
+        Ok(Err(error)) => error_reply(error),
+        Err(_) => error_reply(StoreError::other(anyhow::anyhow!(
+            "storage plugin panicked"
+        ))),
+    };
+    // SAFETY: V1 caller supplies an uninitialized writable Reply.
+    unsafe { out.write(reply) };
+}
+
+unsafe extern "C" fn release_store(context: *mut c_void) {
+    let _ = catch_unwind(AssertUnwindSafe(|| {
+        // SAFETY: Endpoint ownership releases this allocation exactly once.
+        drop(unsafe { Box::from_raw(context.cast::<StoreState>()) });
+    }));
+}
+
+async fn dispatch(state: &StoreState, operation: Operation, body: abi::Stream) -> Result<Reply> {
+    let store = &state.store;
+    let mut reply = Reply::default();
+    reply.metadata = match operation {
+        Operation::Get { key, options } => match store.get(&key, options.into()).await? {
+            GetResult::NotModified { version } => json(&ReadResult::NotModified {
+                version: version.to_string(),
+            })?,
+            GetResult::Object { meta, body } => {
+                reply.body = expose_stream(body, state.runtime.clone());
+                json(&ReadResult::Object { meta: meta.into() })?
+            }
+        },
+        Operation::Head { key } => json(&store.head(&key).await?.map(Meta::from))?,
+        Operation::Put {
+            key,
+            len,
+            mode,
+            immutable,
+            content_type,
+        } => {
+            let meta = store
+                .put(
+                    &key,
+                    PutBody::Stream {
+                        len,
+                        stream: receive_stream(body, None),
+                    },
+                    put_options(mode, immutable, content_type.as_deref()),
+                )
+                .await?;
+            return Ok(Reply {
+                metadata: json(&Meta::from(meta))?,
+                ..Reply::default()
+            });
+        }
+        Operation::Delete { key, version } => {
+            store.delete(&key, version.map(Version::new)).await?;
+            json(&())?
+        }
+        Operation::List {
+            prefix,
+            start_after,
+        } => {
+            let lines = store.list(&prefix, start_after.as_deref()).map(|item| {
+                let mut bytes =
+                    serde_json::to_vec(&Meta::from(item?)).map_err(StoreError::other)?;
+                bytes.push(b'\n');
+                Ok(Bytes::from(bytes))
+            });
+            reply.body = expose_stream(Box::pin(lines), state.runtime.clone());
+            json(&())?
+        }
+        Operation::ListPrefixes { prefix } => json(&store.list_prefixes(&prefix).await?)?,
+        Operation::SignedGetUrl { key, ttl_secs } => json(
+            &store
+                .signed_get_url(&key, Duration::from_secs(ttl_secs))
+                .await?,
+        )?,
+        Operation::AccelTarget { key } => json(&store.accel_target(&key).await.map(|a| Accel {
+            url: a.url,
+            authorization: a.authorization,
+        }))?,
+        Operation::Compose {
+            key,
+            sources,
+            mode,
+            immutable,
+            content_type,
+        } => json(&Meta::from(
+            store
+                .compose(
+                    &key,
+                    &sources,
+                    put_options(mode, immutable, content_type.as_deref()),
+                )
+                .await?,
+        ))?,
+    };
+    Ok(reply)
+}
+
+#[derive(Clone)]
+pub struct RemoteStore {
+    endpoint: Arc<Endpoint>,
+}
+impl RemoteStore {
+    pub fn new(store: abi::Store) -> Self {
+        Self {
+            endpoint: Arc::new(Endpoint(store)),
+        }
+    }
+
+    async fn call(&self, operation: Operation, body: Option<ByteStream>) -> Result<Reply> {
+        let metadata = serde_json::to_vec(&operation).map_err(StoreError::other)?;
+        if metadata.len() > abi::MAX_METADATA {
+            return Err(StoreError::InvalidArgument(
+                "plugin metadata exceeds limit".into(),
+            ));
+        }
+        let body = body.map_or_else(abi::Stream::default, |body| {
+            expose_stream(body, Handle::current())
+        });
+        let endpoint = self.endpoint.clone();
+        tokio::task::spawn_blocking(move || {
+            let mut reply = Reply::default();
+            let request = Request {
+                metadata: metadata.as_slice().into(),
+                body,
+            };
+            // SAFETY: Endpoint lives through the call; request transfers body.
+            unsafe { (endpoint.0.request)(endpoint.0.context, request, &raw mut reply) };
+            match reply.status {
+                0 => Ok(reply),
+                -1 => Err(StoreError::from(decode::<WireError>(&reply.metadata)?)),
+                _ => Err(StoreError::other(anyhow::anyhow!(
+                    "invalid storage plugin status"
+                ))),
+            }
+        })
+        .await
+        .map_err(StoreError::other)?
+    }
+}
+
+#[async_trait::async_trait]
+impl ObjectStore for RemoteStore {
+    fn backend(&self) -> &'static str {
+        "plugin"
+    }
+    async fn get(&self, key: &str, options: GetOptions) -> Result<GetResult> {
+        let reply = self
+            .call(
+                Operation::Get {
+                    key: key.into(),
+                    options: options.into(),
+                },
+                None,
+            )
+            .await?;
+        Ok(match decode(&reply.metadata)? {
+            ReadResult::NotModified { version } => GetResult::NotModified {
+                version: Version::new(version),
+            },
+            ReadResult::Object { meta } => GetResult::Object {
+                meta: meta.into(),
+                body: receive_stream(reply.body, Some(self.endpoint.clone())),
+            },
+        })
+    }
+    async fn head(&self, key: &str) -> Result<Option<ObjectMeta>> {
+        let reply = self.call(Operation::Head { key: key.into() }, None).await?;
+        Ok(decode::<Option<Meta>>(&reply.metadata)?.map(Into::into))
+    }
+    async fn put(&self, key: &str, body: PutBody, options: PutOptions) -> Result<ObjectMeta> {
+        let (len, stream) = match body {
+            PutBody::Bytes(bytes) => (bytes.len() as u64, walgit_store::util::once(bytes)),
+            PutBody::Stream { len, stream } => (len, stream),
+            PutBody::File(path) => (
+                tokio::fs::metadata(&path)
+                    .await
+                    .map_err(StoreError::other)?
+                    .len(),
+                walgit_store::util::file_stream(path, None, abi::MAX_FRAME),
+            ),
+        };
+        let reply = self
+            .call(
+                Operation::Put {
+                    key: key.into(),
+                    len,
+                    mode: options.mode.into(),
+                    immutable: options.immutable,
+                    content_type: options.content_type.map(str::to_owned),
+                },
+                Some(stream),
+            )
+            .await?;
+        Ok(decode::<Meta>(&reply.metadata)?.into())
+    }
+    async fn delete(&self, key: &str, version: Option<Version>) -> Result<()> {
+        self.call(
+            Operation::Delete {
+                key: key.into(),
+                version: version.map(|v| v.to_string()),
+            },
+            None,
+        )
+        .await?;
+        Ok(())
+    }
+    fn list(
+        &self,
+        prefix: &str,
+        start_after: Option<&str>,
+    ) -> BoxStream<'static, Result<ObjectMeta>> {
+        let this = self.clone();
+        let operation = Operation::List {
+            prefix: prefix.into(),
+            start_after: start_after.map(str::to_owned),
+        };
+        // Newline framing permits the byte stream to split a JSON record.
+        Box::pin(
+            futures::stream::once(async move {
+                let reply = this.call(operation, None).await?;
+                let body = receive_stream(reply.body, Some(this.endpoint.clone()));
+                Ok::<_, StoreError>(futures::stream::try_unfold(
+                    (body, Vec::new()),
+                    |(mut body, mut pending)| async move {
+                        loop {
+                            if let Some(end) = pending.iter().position(|b| *b == b'\n') {
+                                let line: Vec<_> = pending.drain(..=end).collect();
+                                let meta: Meta =
+                                    serde_json::from_slice(&line).map_err(StoreError::other)?;
+                                return Ok(Some((meta.into(), (body, pending))));
+                            }
+                            if pending.len() > abi::MAX_METADATA {
+                                return Err(StoreError::InvalidArgument(
+                                    "plugin list record exceeds limit".into(),
+                                ));
+                            }
+                            match body.next().await {
+                                Some(chunk) => pending.extend_from_slice(&chunk?),
+                                None if pending.is_empty() => return Ok(None),
+                                None => {
+                                    return Err(StoreError::other(anyhow::anyhow!(
+                                        "truncated plugin listing"
+                                    )));
+                                }
+                            }
+                        }
+                    },
+                ))
+            })
+            .try_flatten(),
+        )
+    }
+    async fn list_prefixes(&self, prefix: &str) -> Result<Vec<String>> {
+        let reply = self
+            .call(
+                Operation::ListPrefixes {
+                    prefix: prefix.into(),
+                },
+                None,
+            )
+            .await?;
+        decode(&reply.metadata)
+    }
+    async fn signed_get_url(&self, key: &str, ttl: Duration) -> Result<Option<String>> {
+        let reply = self
+            .call(
+                Operation::SignedGetUrl {
+                    key: key.into(),
+                    ttl_secs: ttl.as_secs(),
+                },
+                None,
+            )
+            .await?;
+        decode(&reply.metadata)
+    }
+    async fn accel_target(&self, key: &str) -> Option<AccelTarget> {
+        let reply = self
+            .call(Operation::AccelTarget { key: key.into() }, None)
+            .await
+            .ok()?;
+        decode::<Option<Accel>>(&reply.metadata)
+            .ok()?
+            .map(|a| AccelTarget {
+                url: a.url,
+                authorization: a.authorization,
+            })
+    }
+    fn supports_compose(&self) -> bool {
+        self.endpoint.0.supports_compose == 1
+    }
+    fn compose_is_native(&self) -> bool {
+        self.endpoint.0.compose_is_native == 1
+    }
+    async fn compose(
+        &self,
+        key: &str,
+        sources: &[String],
+        options: PutOptions,
+    ) -> Result<ObjectMeta> {
+        let reply = self
+            .call(
+                Operation::Compose {
+                    key: key.into(),
+                    sources: sources.into(),
+                    mode: options.mode.into(),
+                    immutable: options.immutable,
+                    content_type: options.content_type.map(str::to_owned),
+                },
+                None,
+            )
+            .await?;
+        Ok(decode::<Meta>(&reply.metadata)?.into())
+    }
+}
+
+/// Implementation behind `export_plugin!`. All panics stop at this C boundary.
+/// # Safety
+/// V1 create owns inner and must receive valid borrowed config and writable out/error.
+pub unsafe fn export<F, Fut>(
+    inner: abi::Store,
+    config: Slice,
+    out: *mut abi::Store,
+    error: *mut Buffer,
+    factory: F,
+) -> i32
+where
+    F: FnOnce(DynStore, serde_json::Value) -> Fut,
+    Fut: Future<Output = anyhow::Result<DynStore>>,
+{
+    let inner: DynStore = Arc::new(RemoteStore::new(inner));
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        // SAFETY: V1 caller holds config readable until create returns.
+        let bytes = unsafe { abi::read_slice(config, abi::MAX_METADATA) }?;
+        let config = serde_json::from_slice(bytes)?;
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()?;
+        let store = runtime.block_on(factory(inner, config))?;
+        Ok::<_, anyhow::Error>(expose(store, runtime.handle().clone(), Some(runtime)))
+    }));
+    match result {
+        Ok(Ok(store)) => {
+            // SAFETY: Success initializes caller's store output exactly once.
+            unsafe { out.write(store) };
+            0
+        }
+        error_result => {
+            let message = match error_result {
+                Ok(Err(e)) => e.to_string(),
+                _ => "storage plugin initialization panicked".into(),
+            };
+            // SAFETY: Failure initializes caller's error output exactly once.
+            unsafe { error.write(abi::own_buffer(message.into_bytes())) };
+            -1
+        }
+    }
+}

--- a/crates/walgit-store-plugin/src/lib.rs
+++ b/crates/walgit-store-plugin/src/lib.rs
@@ -48,16 +48,22 @@ macro_rules! export_plugin {
         #[abi_stable::export_root_module]
         pub fn get_library() -> $crate::abi::PluginRef {
             use $crate::abi_stable::prefix_type::PrefixTypeTrait;
-            extern "C" fn create(
-                inner: $crate::abi::Store,
-                config: $crate::abi_stable::std_types::RVec<u8>,
-            ) -> $crate::abi_stable::std_types::RResult<
-                $crate::abi::Store,
-                $crate::abi_stable::std_types::RString,
-            > {
-                $crate::export(inner, config, $factory)
+            struct Factory;
+            impl Factory {
+                extern "C" fn create(
+                    inner: $crate::abi::Store,
+                    config: $crate::abi_stable::std_types::RVec<u8>,
+                ) -> $crate::abi_stable::std_types::RResult<
+                    $crate::abi::Store,
+                    $crate::abi_stable::std_types::RString,
+                > {
+                    $crate::export(inner, config, $factory)
+                }
             }
-            $crate::abi::Plugin { create }.leak_into_prefix()
+            $crate::abi::Plugin {
+                create: Factory::create,
+            }
+            .leak_into_prefix()
         }
     };
 }

--- a/crates/walgit-store-plugin/src/lib.rs
+++ b/crates/walgit-store-plugin/src/lib.rs
@@ -1,106 +1,63 @@
-//! Load a trusted storage cdylib, or export an external `ObjectStore` decorator.
-//! The ABI is C-compatible; the Rust `ObjectStore` trait stays inside each module.
-#![allow(unsafe_code)]
-
+//! Load a checked Rust storage plugin or export an external `ObjectStore` decorator.
 pub mod abi;
 mod bridge;
 mod wire;
 
-use std::path::Path;
-use std::sync::Arc;
-
+use abi_stable::library::lib_header_from_path;
 use anyhow::{Context, Result};
-use libloading::Library;
+use std::{path::Path, sync::Arc};
 use walgit_store::DynStore;
 
+pub use abi_stable;
 pub use bridge::export;
 
-/// Load a library selected by deployment configuration, never by a request.
-/// Libraries remain mapped until process exit: channels and runtime teardown may
-/// execute module code after the last request. Hot unload/reload is unsupported.
+/// Load administrator-selected native code with checked module/type layouts.
+/// Like Rotel, load each path separately; the root-module singleton convenience
+/// loader would incorrectly reuse the first module for every plugin path.
+/// `abi_stable` retains mappings until process exit. Hot unloading is unsupported.
 pub async fn load(path: &Path, config: serde_json::Value, inner: DynStore) -> Result<DynStore> {
     let path = path.to_owned();
     let runtime = tokio::runtime::Handle::current();
+    let config = serde_json::to_vec(&config)?;
+    anyhow::ensure!(
+        config.len() <= abi::MAX_METADATA,
+        "plugin options exceed limit"
+    );
     tokio::task::spawn_blocking(move || {
-        // SAFETY: The operator has selected trusted executable code for this
-        // process. Versioned entry and size are checked before creating a store.
-        let library = unsafe { Library::new(&path) }.context("loading storage plugin")?;
-        // SAFETY: V1 symbol must have the published C signature.
-        let entry = unsafe {
-            library.get::<unsafe extern "C" fn() -> *const abi::Plugin>(b"walgit_store_plugin_v1\0")
-        }
-        .context("storage plugin has no V1 entry point")?;
-        // SAFETY: Calling the documented entry point of the trusted library.
-        let descriptor = unsafe { entry() };
-        anyhow::ensure!(!descriptor.is_null(), "null storage plugin descriptor");
-        // SAFETY: Every entry must expose the fixed two-u32 header, including
-        // incompatible descriptors. Do not read the function table until checked.
-        let header = unsafe { &*descriptor.cast::<abi::PluginHeader>() };
-        anyhow::ensure!(
-            header.abi_version == abi::ABI_VERSION,
-            "unsupported storage plugin ABI"
-        );
-        anyhow::ensure!(
-            usize::try_from(header.struct_size)? == std::mem::size_of::<abi::Plugin>(),
-            "storage plugin ABI size mismatch"
-        );
-        // SAFETY: The trusted descriptor now declares the exact V1 layout.
-        let descriptor = unsafe { &*descriptor };
-        let create = descriptor.create;
-        // Only the shared code mapping is retained. Stores, streams and buffers
-        // still have explicit ownership and are destroyed normally.
-        let _mapped = Box::leak(Box::new(library));
+        let header = lib_header_from_path(&path).context("loading storage plugin")?;
+        let module: abi::PluginRef = header
+            .init_root_module()
+            .context("checking storage plugin ABI")?;
         let host = bridge::expose(inner, runtime, None);
-        let config = serde_json::to_vec(&config)?;
-        let mut out = std::mem::MaybeUninit::<abi::Store>::uninit();
-        let mut error = abi::Buffer::default();
-        // SAFETY: Inputs live through create; create consumes host even on error.
-        let status = unsafe {
-            create(
-                host,
-                config.as_slice().into(),
-                out.as_mut_ptr(),
-                &raw mut error,
-            )
-        };
-        anyhow::ensure!(
-            status == 0,
-            "storage plugin initialization failed: {}",
-            bridge::error_text(&error)
-        );
-        // SAFETY: A successful V1 create initializes out.
-        let endpoint = unsafe { out.assume_init() };
+        let endpoint = (module.create())(host, config.into())
+            .into_result()
+            .map_err(|error| anyhow::anyhow!("storage plugin initialization failed: {error}"))?;
         Ok::<DynStore, anyhow::Error>(Arc::new(bridge::RemoteStore::new(endpoint)))
     })
     .await
     .context("storage plugin loader task failed")?
 }
 
-/// Export a factory async function `(DynStore, serde_json::Value) -> Result<DynStore>`.
-/// The factory receives the configured backend with its global prefix already
-/// applied. Keys visible to the decorator are logical, unprefixed object keys.
+/// Export an async factory `(DynStore, serde_json::Value) -> Result<DynStore>`.
+/// Decorators see logical object keys, with the global prefix applied underneath.
+/// The implementation crate must depend on `abi_stable` 0.11, like this SDK.
 #[macro_export]
 macro_rules! export_plugin {
     ($factory:path) => {
         #[allow(unsafe_code)]
-        unsafe extern "C" fn walgit_plugin_create(
-            inner: $crate::abi::Store,
-            config: $crate::abi::Slice,
-            out: *mut $crate::abi::Store,
-            error: *mut $crate::abi::Buffer,
-        ) -> i32 {
-            // SAFETY: Forward the V1 loader's documented ownership contract.
-            unsafe { $crate::export(inner, config, out, error, $factory) }
-        }
-        #[allow(unsafe_code)]
-        #[unsafe(no_mangle)]
-        pub extern "C" fn walgit_store_plugin_v1() -> *const $crate::abi::Plugin {
-            static PLUGIN: $crate::abi::Plugin = $crate::abi::Plugin {
-                abi_version: $crate::abi::ABI_VERSION,
-                struct_size: std::mem::size_of::<$crate::abi::Plugin>() as u32,
-                create: walgit_plugin_create,
-            };
-            &PLUGIN
+        #[abi_stable::export_root_module]
+        pub fn get_library() -> $crate::abi::PluginRef {
+            use $crate::abi_stable::prefix_type::PrefixTypeTrait;
+            extern "C" fn create(
+                inner: $crate::abi::Store,
+                config: $crate::abi_stable::std_types::RVec<u8>,
+            ) -> $crate::abi_stable::std_types::RResult<
+                $crate::abi::Store,
+                $crate::abi_stable::std_types::RString,
+            > {
+                $crate::export(inner, config, $factory)
+            }
+            $crate::abi::Plugin { create }.leak_into_prefix()
         }
     };
 }

--- a/crates/walgit-store-plugin/src/lib.rs
+++ b/crates/walgit-store-plugin/src/lib.rs
@@ -1,0 +1,106 @@
+//! Load a trusted storage cdylib, or export an external `ObjectStore` decorator.
+//! The ABI is C-compatible; the Rust `ObjectStore` trait stays inside each module.
+#![allow(unsafe_code)]
+
+pub mod abi;
+mod bridge;
+mod wire;
+
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use libloading::Library;
+use walgit_store::DynStore;
+
+pub use bridge::export;
+
+/// Load a library selected by deployment configuration, never by a request.
+/// Libraries remain mapped until process exit: channels and runtime teardown may
+/// execute module code after the last request. Hot unload/reload is unsupported.
+pub async fn load(path: &Path, config: serde_json::Value, inner: DynStore) -> Result<DynStore> {
+    let path = path.to_owned();
+    let runtime = tokio::runtime::Handle::current();
+    tokio::task::spawn_blocking(move || {
+        // SAFETY: The operator has selected trusted executable code for this
+        // process. Versioned entry and size are checked before creating a store.
+        let library = unsafe { Library::new(&path) }.context("loading storage plugin")?;
+        // SAFETY: V1 symbol must have the published C signature.
+        let entry = unsafe {
+            library.get::<unsafe extern "C" fn() -> *const abi::Plugin>(b"walgit_store_plugin_v1\0")
+        }
+        .context("storage plugin has no V1 entry point")?;
+        // SAFETY: Calling the documented entry point of the trusted library.
+        let descriptor = unsafe { entry() };
+        anyhow::ensure!(!descriptor.is_null(), "null storage plugin descriptor");
+        // SAFETY: Every entry must expose the fixed two-u32 header, including
+        // incompatible descriptors. Do not read the function table until checked.
+        let header = unsafe { &*descriptor.cast::<abi::PluginHeader>() };
+        anyhow::ensure!(
+            header.abi_version == abi::ABI_VERSION,
+            "unsupported storage plugin ABI"
+        );
+        anyhow::ensure!(
+            usize::try_from(header.struct_size)? == std::mem::size_of::<abi::Plugin>(),
+            "storage plugin ABI size mismatch"
+        );
+        // SAFETY: The trusted descriptor now declares the exact V1 layout.
+        let descriptor = unsafe { &*descriptor };
+        let create = descriptor.create;
+        // Only the shared code mapping is retained. Stores, streams and buffers
+        // still have explicit ownership and are destroyed normally.
+        let _mapped = Box::leak(Box::new(library));
+        let host = bridge::expose(inner, runtime, None);
+        let config = serde_json::to_vec(&config)?;
+        let mut out = std::mem::MaybeUninit::<abi::Store>::uninit();
+        let mut error = abi::Buffer::default();
+        // SAFETY: Inputs live through create; create consumes host even on error.
+        let status = unsafe {
+            create(
+                host,
+                config.as_slice().into(),
+                out.as_mut_ptr(),
+                &raw mut error,
+            )
+        };
+        anyhow::ensure!(
+            status == 0,
+            "storage plugin initialization failed: {}",
+            bridge::error_text(&error)
+        );
+        // SAFETY: A successful V1 create initializes out.
+        let endpoint = unsafe { out.assume_init() };
+        Ok::<DynStore, anyhow::Error>(Arc::new(bridge::RemoteStore::new(endpoint)))
+    })
+    .await
+    .context("storage plugin loader task failed")?
+}
+
+/// Export a factory async function `(DynStore, serde_json::Value) -> Result<DynStore>`.
+/// The factory receives the configured backend with its global prefix already
+/// applied. Keys visible to the decorator are logical, unprefixed object keys.
+#[macro_export]
+macro_rules! export_plugin {
+    ($factory:path) => {
+        #[allow(unsafe_code)]
+        unsafe extern "C" fn walgit_plugin_create(
+            inner: $crate::abi::Store,
+            config: $crate::abi::Slice,
+            out: *mut $crate::abi::Store,
+            error: *mut $crate::abi::Buffer,
+        ) -> i32 {
+            // SAFETY: Forward the V1 loader's documented ownership contract.
+            unsafe { $crate::export(inner, config, out, error, $factory) }
+        }
+        #[allow(unsafe_code)]
+        #[unsafe(no_mangle)]
+        pub extern "C" fn walgit_store_plugin_v1() -> *const $crate::abi::Plugin {
+            static PLUGIN: $crate::abi::Plugin = $crate::abi::Plugin {
+                abi_version: $crate::abi::ABI_VERSION,
+                struct_size: std::mem::size_of::<$crate::abi::Plugin>() as u32,
+                create: walgit_plugin_create,
+            };
+            &PLUGIN
+        }
+    };
+}

--- a/crates/walgit-store-plugin/src/wire.rs
+++ b/crates/walgit-store-plugin/src/wire.rs
@@ -1,0 +1,205 @@
+use serde::{Deserialize, Serialize};
+use walgit_store::{GetOptions, ObjectMeta, PutMode, PutOptions, StoreError, Version};
+
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case", deny_unknown_fields)]
+pub enum Operation {
+    Get {
+        key: String,
+        options: ReadOptions,
+    },
+    Head {
+        key: String,
+    },
+    Put {
+        key: String,
+        len: u64,
+        mode: Mode,
+        immutable: bool,
+        content_type: Option<String>,
+    },
+    Delete {
+        key: String,
+        version: Option<String>,
+    },
+    List {
+        prefix: String,
+        start_after: Option<String>,
+    },
+    ListPrefixes {
+        prefix: String,
+    },
+    SignedGetUrl {
+        key: String,
+        ttl_secs: u64,
+    },
+    AccelTarget {
+        key: String,
+    },
+    Compose {
+        key: String,
+        sources: Vec<String>,
+        mode: Mode,
+        immutable: bool,
+        content_type: Option<String>,
+    },
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReadOptions {
+    pub if_none_match: Option<String>,
+    pub if_match: Option<String>,
+    pub range: Option<std::ops::Range<u64>>,
+}
+impl From<GetOptions> for ReadOptions {
+    fn from(o: GetOptions) -> Self {
+        Self {
+            if_none_match: o.if_none_match.map(|v| v.to_string()),
+            if_match: o.if_match.map(|v| v.to_string()),
+            range: o.range,
+        }
+    }
+}
+impl From<ReadOptions> for GetOptions {
+    fn from(o: ReadOptions) -> Self {
+        Self {
+            if_none_match: o.if_none_match.map(Version::new),
+            if_match: o.if_match.map(Version::new),
+            range: o.range,
+        }
+    }
+}
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "mode", content = "version", rename_all = "snake_case")]
+pub enum Mode {
+    Overwrite,
+    Create,
+    Update(String),
+}
+impl From<PutMode> for Mode {
+    fn from(m: PutMode) -> Self {
+        match m {
+            PutMode::Overwrite => Self::Overwrite,
+            PutMode::Create => Self::Create,
+            PutMode::Update(v) => Self::Update(v.to_string()),
+        }
+    }
+}
+impl From<Mode> for PutMode {
+    fn from(m: Mode) -> Self {
+        match m {
+            Mode::Overwrite => Self::Overwrite,
+            Mode::Create => Self::Create,
+            Mode::Update(v) => Self::Update(Version::new(v)),
+        }
+    }
+}
+
+// ObjectStore's MIME hint has a static lifetime. Only known hints can be
+// represented without leaking a caller-controlled string on each put.
+pub fn put_options(mode: Mode, immutable: bool, content_type: Option<&str>) -> PutOptions {
+    let content_type = match content_type {
+        Some("application/octet-stream") => Some("application/octet-stream"),
+        Some("application/x-git-packed-objects") => Some("application/x-git-packed-objects"),
+        Some("application/x-git-bundle") => Some("application/x-git-bundle"),
+        Some("application/json") => Some("application/json"),
+        Some("application/x-protobuf") => Some("application/x-protobuf"),
+        Some("text/plain") => Some("text/plain"),
+        _ => None,
+    };
+    PutOptions {
+        mode: mode.into(),
+        immutable,
+        content_type,
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Meta {
+    pub key: String,
+    pub size: u64,
+    pub version: String,
+}
+impl From<ObjectMeta> for Meta {
+    fn from(m: ObjectMeta) -> Self {
+        Self {
+            key: m.key,
+            size: m.size,
+            version: m.version.to_string(),
+        }
+    }
+}
+impl From<Meta> for ObjectMeta {
+    fn from(m: Meta) -> Self {
+        Self {
+            key: m.key,
+            size: m.size,
+            version: Version::new(m.version),
+        }
+    }
+}
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "result", rename_all = "snake_case")]
+pub enum ReadResult {
+    Object { meta: Meta },
+    NotModified { version: String },
+}
+#[derive(Serialize, Deserialize)]
+pub struct Accel {
+    pub url: String,
+    pub authorization: Option<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "error", rename_all = "snake_case")]
+pub enum WireError {
+    NotFound {
+        key: String,
+    },
+    PreconditionFailed {
+        key: String,
+        current: Option<String>,
+    },
+    Retryable {
+        message: String,
+    },
+    InvalidArgument {
+        message: String,
+    },
+    Other {
+        message: String,
+    },
+}
+impl From<StoreError> for WireError {
+    fn from(e: StoreError) -> Self {
+        match e {
+            StoreError::NotFound { key } => Self::NotFound { key },
+            StoreError::PreconditionFailed { key, current } => Self::PreconditionFailed {
+                key,
+                current: current.map(|v| v.to_string()),
+            },
+            StoreError::Retryable(e) => Self::Retryable {
+                message: e.to_string(),
+            },
+            StoreError::InvalidArgument(message) => Self::InvalidArgument { message },
+            StoreError::Other(e) => Self::Other {
+                message: e.to_string(),
+            },
+        }
+    }
+}
+impl From<WireError> for StoreError {
+    fn from(e: WireError) -> Self {
+        match e {
+            WireError::NotFound { key } => Self::NotFound { key },
+            WireError::PreconditionFailed { key, current } => Self::PreconditionFailed {
+                key,
+                current: current.map(Version::new),
+            },
+            WireError::Retryable { message } => Self::retryable(anyhow::anyhow!(message)),
+            WireError::InvalidArgument { message } => Self::InvalidArgument(message),
+            WireError::Other { message } => Self::other(anyhow::anyhow!(message)),
+        }
+    }
+}

--- a/crates/walgit-store-plugin/tests/plugin.rs
+++ b/crates/walgit-store-plugin/tests/plugin.rs
@@ -195,41 +195,57 @@ async fn missing_plugin_fails_closed() {
     );
 }
 
-#[cfg(unix)]
 #[tokio::test]
-async fn incompatible_descriptors_are_rejected_before_reading_function_pointers() {
-    let dir = tempfile::tempdir().unwrap();
-    for (version, size) in [(2, 8), (1, 8), (1, 1024)] {
-        let source = dir.path().join(format!("bad-{version}-{size}.c"));
-        let library = source.with_extension(if cfg!(target_os = "macos") {
-            "dylib"
-        } else {
-            "so"
-        });
-        std::fs::write(&source, format!(
-            "#include <stdint.h>\nstruct header {{ uint32_t version, size; }};\nstatic const struct header h = {{{version}, {size}}};\nconst struct header *walgit_store_plugin_v1(void) {{ return &h; }}\n"
-        )).unwrap();
-        let status = std::process::Command::new("cc")
-            .arg(if cfg!(target_os = "macos") {
-                "-dynamiclib"
-            } else {
-                "-shared"
-            })
-            .arg("-fPIC")
-            .arg(&source)
-            .arg("-o")
-            .arg(&library)
-            .status()
-            .unwrap();
-        assert!(status.success());
-        assert!(
-            walgit_store_plugin::load(
-                &library,
-                serde_json::json!({}),
-                Arc::new(MemoryStore::new())
-            )
-            .await
-            .is_err()
-        );
+#[ignore = "requires a built incompatible module; run just test-plugin"]
+async fn incompatible_layout_is_rejected_before_initialization() {
+    let path = std::env::var("WALGIT_TEST_INCOMPATIBLE").unwrap();
+    let result = walgit_store_plugin::load(
+        std::path::Path::new(&path),
+        serde_json::json!({}),
+        Arc::new(MemoryStore::new()),
+    )
+    .await;
+    let error = result.err().expect("wrong module layout must be rejected");
+    assert!(
+        error.to_string().contains("checking storage plugin ABI"),
+        "{error:#}"
+    );
+}
+
+// A reproducible local overhead probe, not a timing assertion or a cloud benchmark.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "manual measurement; set WALGIT_TEST_PLUGIN and run with --nocapture"]
+async fn passthrough_overhead() {
+    let path = std::env::var("WALGIT_TEST_PLUGIN").unwrap();
+    let raw: DynStore = Arc::new(MemoryStore::new());
+    let wrapped = walgit_store_plugin::load(
+        std::path::Path::new(&path),
+        serde_json::json!({}),
+        raw.clone(),
+    )
+    .await
+    .unwrap();
+    for size in [1024, 1024 * 1024, 8 * 1024 * 1024] {
+        raw.put(
+            "bench",
+            PutBody::Bytes(Bytes::from(vec![42; size])),
+            PutOptions::default(),
+        )
+        .await
+        .unwrap();
+        let count = if size == 1024 { 1000_u32 } else { 100_u32 };
+        for (label, store) in [("raw", &raw), ("plugin", &wrapped)] {
+            for _ in 0..10 {
+                std::hint::black_box(store.get_bytes("bench").await.unwrap().unwrap());
+            }
+            let start = std::time::Instant::now();
+            for _ in 0..count {
+                std::hint::black_box(store.get_bytes("bench").await.unwrap().unwrap());
+            }
+            println!(
+                "BENCH bytes={size} path={label} iterations={count} mean_us={:.2}",
+                start.elapsed().as_secs_f64() * 1_000_000.0 / f64::from(count)
+            );
+        }
     }
 }

--- a/crates/walgit-store-plugin/tests/plugin.rs
+++ b/crates/walgit-store-plugin/tests/plugin.rs
@@ -1,0 +1,235 @@
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+
+use bytes::Bytes;
+use futures::{StreamExt, TryStreamExt};
+use std::sync::Arc;
+use walgit_store::{
+    DynStore, GetOptions, GetResult, ObjectStoreExt, Prefixed, PutBody, PutMode, PutOptions,
+    StoreError, memory::MemoryStore,
+};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "requires a built cdylib; run just test-plugin"]
+async fn dynamic_passthrough_preserves_the_store_contract() {
+    let path = std::env::var("WALGIT_TEST_PLUGIN").expect("just test-plugin sets the cdylib path");
+    assert!(
+        walgit_store_plugin::load(
+            std::path::Path::new(&path),
+            serde_json::json!({"unsupported": true}),
+            Arc::new(MemoryStore::new()),
+        )
+        .await
+        .is_err()
+    );
+    let raw: DynStore = Arc::new(MemoryStore::new());
+    let inner: DynStore = Arc::new(Prefixed::new(raw.clone(), "global/"));
+    let store =
+        walgit_store_plugin::load(std::path::Path::new(&path), serde_json::json!({}), inner)
+            .await
+            .unwrap();
+    let bytes = Bytes::from(vec![42; 2 * 1024 * 1024 + 17]);
+    let meta = store
+        .put(
+            "repos/owner/repo/wal/pack",
+            PutBody::Bytes(bytes.clone()),
+            PutMode::Create.into(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(meta.size, bytes.len() as u64);
+    assert!(
+        raw.head("global/repos/owner/repo/wal/pack")
+            .await
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        raw.head("global/global/repos/owner/repo/wal/pack")
+            .await
+            .unwrap()
+            .is_none()
+    );
+    let (_, read) = store.get_bytes(&meta.key).await.unwrap().unwrap();
+    assert_eq!(read, bytes);
+    let range = store
+        .get(
+            &meta.key,
+            GetOptions {
+                range: Some(1_048_570..1_048_590),
+                if_match: Some(meta.version.clone()),
+                ..GetOptions::default()
+            },
+        )
+        .await
+        .unwrap();
+    let GetResult::Object {
+        meta: ranged_meta,
+        body,
+    } = range
+    else {
+        panic!("expected range");
+    };
+    assert_eq!(ranged_meta.size, meta.size);
+    assert_eq!(
+        walgit_store::util::collect(body, 20).await.unwrap(),
+        bytes.slice(1_048_570..1_048_590)
+    );
+    assert!(matches!(
+        store
+            .get(
+                &meta.key,
+                GetOptions {
+                    if_none_match: Some(meta.version.clone()),
+                    ..GetOptions::default()
+                }
+            )
+            .await
+            .unwrap(),
+        GetResult::NotModified { .. }
+    ));
+    let conflicts = futures::future::join_all((0..16).map(|_| {
+        store.put(
+            "race",
+            PutBody::Bytes(Bytes::from_static(b"one")),
+            PutMode::Create.into(),
+        )
+    }))
+    .await;
+    assert_eq!(conflicts.iter().filter(|r| r.is_ok()).count(), 1);
+    assert!(
+        conflicts
+            .iter()
+            .filter(|r| r.is_err())
+            .all(|r| matches!(r, Err(StoreError::PreconditionFailed { .. })))
+    );
+    let updated = store
+        .put(
+            &meta.key,
+            PutBody::Bytes(Bytes::from_static(b"new")),
+            PutMode::Update(meta.version.clone()).into(),
+        )
+        .await
+        .unwrap();
+    assert!(matches!(
+        store.delete(&meta.key, Some(meta.version.clone())).await,
+        Err(StoreError::PreconditionFailed { .. })
+    ));
+    assert!(matches!(
+        store
+            .get(
+                &meta.key,
+                GetOptions {
+                    if_match: Some(meta.version),
+                    ..GetOptions::default()
+                }
+            )
+            .await,
+        Err(StoreError::PreconditionFailed { .. })
+    ));
+    let listed: Vec<_> = store.list("repos/", None).try_collect().await.unwrap();
+    assert_eq!(listed, vec![updated.clone()]);
+    store
+        .delete(&meta.key, Some(updated.version))
+        .await
+        .unwrap();
+    assert!(store.head(&meta.key).await.unwrap().is_none());
+    let failed = futures::stream::iter(vec![
+        Ok(Bytes::from_static(b"partial")),
+        Err(StoreError::retryable(anyhow::anyhow!("interrupted upload"))),
+    ]);
+    assert!(
+        store
+            .put(
+                "interrupted",
+                PutBody::Stream {
+                    len: 100,
+                    stream: Box::pin(failed)
+                },
+                PutOptions::default()
+            )
+            .await
+            .is_err()
+    );
+    assert!(store.head("interrupted").await.unwrap().is_none());
+    let file = tempfile::NamedTempFile::new().unwrap();
+    tokio::fs::write(file.path(), b"file body").await.unwrap();
+    store
+        .put(
+            "file",
+            PutBody::File(file.path().into()),
+            PutOptions::default(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        store.get_bytes("file").await.unwrap().unwrap().1,
+        "file body"
+    );
+    assert!(
+        store
+            .signed_get_url("file", std::time::Duration::from_mins(1))
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(store.accel_target("file").await.is_none());
+    let result = store.get("file", GetOptions::default()).await.unwrap();
+    let GetResult::Object { mut body, .. } = result else {
+        panic!("expected object");
+    };
+    drop(store); // response stream must keep the plugin runtime/store alive
+    assert_eq!(body.next().await.unwrap().unwrap(), "file body");
+}
+
+#[tokio::test]
+async fn missing_plugin_fails_closed() {
+    let inner: DynStore = Arc::new(MemoryStore::new());
+    assert!(
+        walgit_store_plugin::load(
+            std::path::Path::new("/no-such-walgit-plugin.so"),
+            serde_json::json!({}),
+            inner
+        )
+        .await
+        .is_err()
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn incompatible_descriptors_are_rejected_before_reading_function_pointers() {
+    let dir = tempfile::tempdir().unwrap();
+    for (version, size) in [(2, 8), (1, 8), (1, 1024)] {
+        let source = dir.path().join(format!("bad-{version}-{size}.c"));
+        let library = source.with_extension(if cfg!(target_os = "macos") {
+            "dylib"
+        } else {
+            "so"
+        });
+        std::fs::write(&source, format!(
+            "#include <stdint.h>\nstruct header {{ uint32_t version, size; }};\nstatic const struct header h = {{{version}, {size}}};\nconst struct header *walgit_store_plugin_v1(void) {{ return &h; }}\n"
+        )).unwrap();
+        let status = std::process::Command::new("cc")
+            .arg(if cfg!(target_os = "macos") {
+                "-dynamiclib"
+            } else {
+                "-shared"
+            })
+            .arg("-fPIC")
+            .arg(&source)
+            .arg("-o")
+            .arg(&library)
+            .status()
+            .unwrap();
+        assert!(status.success());
+        assert!(
+            walgit_store_plugin::load(
+                &library,
+                serde_json::json!({}),
+                Arc::new(MemoryStore::new())
+            )
+            .await
+            .is_err()
+        );
+    }
+}

--- a/crates/walgit-store/src/lib.rs
+++ b/crates/walgit-store/src/lib.rs
@@ -629,6 +629,8 @@ impl ObjectStore for Prefixed {
 }
 
 /// Open a store backend by config, wrapped in the global key prefix.
+// Keep the same async API when an external plugin needs only the memory backend.
+#[cfg_attr(not(any(feature = "s3", feature = "gcs")), allow(clippy::unused_async))]
 pub async fn open_store(cfg: &walgit_config::Config) -> anyhow::Result<DynStore> {
     let prefix = cfg.store_prefix();
     let inner: DynStore = match cfg.store.backend {

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -290,7 +290,7 @@ where configured. Do not derive scheduling behavior from this interface catalog.
 
 Optional `[store.plugin]` loads a versioned external ObjectStore decorator for
 every storage-using CLI command. See [STORAGE_PLUGINS.md](STORAGE_PLUGINS.md) for
-the C ABI, prefix ordering, ownership, failure and compatibility contract.
+the checked Rust ABI, prefix ordering, ownership, failure and compatibility contract.
 `ObjectStore` and existing entry points are unchanged; only deployment-selected
 shared libraries are loaded. The upstream example is pass-through.
 `walgit --config walgit.toml <cmd>`: `serve` | `compact [owner/name|--all] [--once]` | `bundle run [--repo] [--strategy]` |

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -287,6 +287,12 @@ slot, slot-epoch creation tokens, oldest-first backfill, contiguous-chain retent
 where configured. Do not derive scheduling behavior from this interface catalog.
 
 ## walgit-cli (owner: Cli)
+
+Optional `[store.plugin]` loads a versioned external ObjectStore decorator for
+every storage-using CLI command. See [STORAGE_PLUGINS.md](STORAGE_PLUGINS.md) for
+the C ABI, prefix ordering, ownership, failure and compatibility contract.
+`ObjectStore` and existing entry points are unchanged; only deployment-selected
+shared libraries are loaded. The upstream example is pass-through.
 `walgit --config walgit.toml <cmd>`: `serve` | `compact [owner/name|--all] [--once]` | `bundle run [--repo] [--strategy]` |
 `repo create|list|info` | `wal ls|show|materialize --at-seq` | `synth --out DIR --size s|m|l [--commits N --files M]`
 | `import --from GITDIR owner/name` | `config check|dump`. Also `Containerfile`, `compose.yaml` (rustfs +

--- a/docs/ROUNDTRIPS.md
+++ b/docs/ROUNDTRIPS.md
@@ -46,6 +46,7 @@ right shape. This document is the thinking tool; apply it to every protocol chan
 | Checkpoint | 1 cond GET (freshness) → refs PUT ∥ checkpoint PUT → manifest CAS | 3 rounds, 4 requests (was 6/6 until 2026-08-22: a bundle-list GET before the checkpoint PUT and a log GET for provenance times sat in the chain; times now come from the writer's own applied state, `bundle_key` is no longer looked up) | `checkpoint.rs` |
 | Settings publish (D24) | refs sync (conditional GET) → log slot PUT → manifest CAS; readers pay nothing extra (settings ride inline on the manifest) | 3 rounds; read: 0 | `publish.rs::publish_settings_impl` |
 | Lease acquire | 1 GET → 1 CAS put (or 1 Create when absent) | 2 | `coord.rs::try_acquire` |
+| Store plugin decorator (`[store.plugin]`) | none: the decorator is in-process, so every budget above is unchanged | +0 | `walgit-store-plugin/src/bridge.rs` |
 | Publish, local commit (2026-08-23) | unchanged in round trips: after the manifest CAS the ref txns are applied to the local copy **before** the new manifest version is advertised, both under `sync_mutex` (the refs phase of every sync); the reverse order let a reader cache the old refs under the new version, and without the lock a concurrent sync replayed the same entry (two `update-ref`, a lock collision). A landed CAS is answered `ok` whatever the local apply does — the next sync replays (one conditional GET that then returns 200, no extra write). | 0 extra | `publish.rs::process_batch` |
 | Weekly compose: refs at the base's seq (`refs_at_seq`, 2026-08-23) | checkpoint `refs.pb` at that seq: 1 GET; else newest checkpoint ≤ seq (2 GETs) + the log entries through the seq (already cached by the refs sync in practice) — replayed in memory, never a local write | 1, or 2 + tail | `log_reader.rs::refs_at_seq`, `bundles.rs::compose_full_from_base` |
 | Maintainer bundle pass, refs level (retention + settle closed slots) | 1 list GET → at most 1 CAS (retention) → at most **1 CAS for every verdict of the pass** (`record_skipped_many`; was one CAS per settled slot until 2026-08-22: a rig repo with 9,654 closed slots paid 9,654 CAS per pass and, past the 4,096-verdict cap, forever) | ≤ 3 | `walgit-bundle/src/lib.rs::settle_closed_slots`, `ops.rs::record_skipped_many` |
@@ -61,6 +62,15 @@ only after Create/CAS failure, so the measured happy-path counts remain unchange
 Keep this table current; when you change a protocol, update the row and put the before/after depth in the
 commit message. The sim harness can enforce it: `FaultStore::stats().ops` counts exact store requests per
 link, so a scenario can assert "a push on a healthy link is ≤ N requests" as a regression test.
+
+A plugin adds no object-store round trips, but it is not free and its cost does not
+appear in this table. Each operation crosses the library boundary as one metadata frame
+plus one frame per `MAX_FRAME` of body, and each frame is a `spawn_blocking` hop — on the
+same pool the control plane uses, so a large clone and a `head` contend (see §4). A
+decorator that talks to anything itself (a KMS, a sealing service) adds round trips this
+table cannot predict: that budget belongs to the plugin and its author must count it the
+same way. Measure a decorator against `just test-plugin` and the `passthrough_overhead`
+probe before deploying it.
 
 ## 3. Rules of thumb
 - **Depth before count.** Two PUTs in parallel cost one round trip; the same two in sequence cost two.

--- a/docs/STORAGE_PLUGINS.md
+++ b/docs/STORAGE_PLUGINS.md
@@ -19,42 +19,51 @@ exactly once. The decorator sees **logical keys before that prefix**. A plugin
 needing bucket/domain identity must receive a stable identifier explicitly. It
 must not infer tenant authority from an unverified request.
 
-## V1 boundary
+## Checked Rust boundary and rationale
 
-`walgit_store_plugin_v1` returns the version/size-checked C descriptor in
-`walgit-store-plugin/src/abi.rs`. The ABI uses `repr(C)` structures, C function
-pointers, fixed-width status fields, pointer-sized byte lengths and opaque
-contexts. Both sides must target the same architecture/OS. No Rust trait object,
-allocator ownership, future, string layout or unwind crosses the boundary. Rust
-plugins use `crate-type = ["cdylib"]`; no Rust compiler-specific `dylib` ABI is used.
+The interface uses [`abi_stable` 0.11.3](https://docs.rs/abi_stable/0.11.3/abi_stable/),
+with a `RootModule`, `StableAbi` layouts, `sabi_trait` endpoints and owned
+`RBox`/`RVec`/`RString` values. A normal Rust trait object is not a stable dynamic
+library interface. This mechanism checks module versions and layouts at load time
+and provides allocator-correct ownership/destruction across independently built
+Rust libraries. It follows [Rotel's Rust processor SDK](https://github.com/streamfold/rotel/blob/v0.2.5/rotel_rust_processor_sdk/src/lib.rs)
+and its async processor bridge. Safety and maintenance are the reasons for this
+choice, rather than an assumed performance gain. This is a Rust plugin API;
+plugins written in other languages would need a separate adapter.
 
-Request and result metadata are bounded UTF-8 JSON described by `wire.rs`; bytes
-are separate, pull-based streams with at most 1 MiB per frame. JSON owns no pack
-bytes. PUT takes an explicit logical length; bytes/file/stream inputs all become
-streams at the boundary. LIST is streamed as newline-delimited metadata records.
-Reads return the whole object's logical size even when their body is a range.
-Errors preserve not-found, precondition, not-modified and retryable outcomes.
-Backing versions remain opaque strings. MIME types are advisory hints; the SDK
-forwards the known Git/JSON/protobuf/plain/octet-stream hints and drops unknown
-hints rather than leaking per-request static strings.
+`abi.rs` still has `repr(C)`/`extern "C"` declarations underneath the checked
+interface. The SDK contains no hand-written raw-pointer dereferences, allocator
+release callbacks or manual vtables. `lib_header_from_path` plus
+`init_root_module` checks each library independently, as Rotel does; the singleton
+root-module loader would accidentally reuse the first plugin for subsequent paths.
+Both sides must target the same OS/architecture and compatible SDK/abi_stable
+versions. Incompatible layouts fail before initialization; there is no unchecked
+loading path. Implementation crates depend on abi_stable and export their async
+factory with `walgit_store_plugin::export_plugin!`.
 
-Each allocation carries its allocating module's release callback. Each stream
-has exactly one owner; release drops/cancels it without draining. Calls on
-different stores/streams may run concurrently, while one stream is polled
-serially. An endpoint outlives its calls and result streams. Create consumes the
-inner endpoint on success and failure. Every exported callback catches unwinding
-panics and reports failure. A panic-abort build can still terminate the process.
+Operation metadata is bounded UTF-8 JSON described by `wire.rs`; pack bytes are
+separate pull-based streams with at most 1 MiB per frame. PUT retains its explicit
+logical length. LIST streams newline-delimited records. Reads report the whole
+logical object size, including for ranges, and errors preserve not-found,
+precondition, not-modified and retryable outcomes. Versions stay opaque. Known
+Git/JSON/protobuf/plain/octet-stream MIME hints are forwarded; unknown advisory
+hints are omitted instead of leaking per-request static strings.
 
-Callbacks are synchronous and run on blocking executor threads. The SDK bridges
-to the module's own Tokio runtime, preserving bounded streaming and backpressure;
-it never calls block_on from an async worker. Plugins are trusted native code,
-not a sandbox. Libraries stay mapped until process exit to keep runtime/channel
-teardown safe; upgrade by rolling the process, not hot-unloading a library.
+Calls run on blocking executor threads and bridge to the module's own Tokio
+runtime; application futures stay within their module. Streams are polled
+serially, distinct calls may run concurrently, and response streams keep their
+endpoint alive. Dropping a stream cancels without draining. Returned RVec frames
+retain their owner through Bytes, avoiding an additional receiver-side copy.
+Factory/request/poll panics are converted to errors; aborting panics or panicking
+destructors can still terminate the process. Native plugins remain trusted code,
+not a sandbox. abi_stable retains mappings until process exit; upgrades roll
+processes, never hot-unload code.
 
-ABI evolution uses a new versioned symbol for incompatible layouts or semantics.
-Unknown operations fail, rather than falling back to the raw store. Test plugins
-against the pinned core revision before upgrades. Load only immutable library
-paths baked into the image or administrator-controlled read-only mounts.
+Public interface changes follow abi_stable's layout/evolution rules. The generic
+plugin preserves the existing ObjectStore trait and no-plugin CLI behavior. The
+only functional example is pass-through; its deliberately incompatible test
+module exists solely to exercise load-time rejection. No encryption or tenant
+policy is implemented here.
 
 ## Decorator obligations
 
@@ -82,3 +91,22 @@ streaming/file uploads, ranges across frames, CAS races, conditional reads/delet
 listing, prefix application, interrupted uploads and stream lifetime after the
 store handle is dropped. Also run ordinary Git/maintenance tests through the
 plugin before deploying a custom adapter.
+
+### Local overhead measurement
+
+A macOS arm64, test-profile `MemoryStore` probe (three alternating runs; median
+of each run's mean full-GET latency) measured:
+
+| Object bytes | Manual ABI prototype | abi_stable implementation |
+|---|---:|---:|
+| 1 KiB | 66.12 µs | 66.92 µs |
+| 1 MiB | 127.93 µs | 97.84 µs |
+| 8 MiB | 840.27 µs | 602.14 µs |
+
+Small-object overhead is comparable in this sample. The new implementation also
+avoids a receiver-side frame copy, so this does **not** isolate the cost of the
+ABI library itself. These are local in-memory timings, not a production throughput
+claim: no S3/GCS, Git, encryption or KMS is included. Safety and consistency decide
+the implementation choice; measure the real adapter's workload separately.
+The ignored `passthrough_overhead` test reproduces the current implementation's
+probe with `WALGIT_TEST_PLUGIN` set, `--ignored --nocapture --test-threads=1`.

--- a/docs/STORAGE_PLUGINS.md
+++ b/docs/STORAGE_PLUGINS.md
@@ -1,0 +1,84 @@
+# External storage plugins
+
+An optional, operator-installed `cdylib` decorates the configured S3, GCS or memory
+store. The stock build contains no encryption or application identity policy.
+`examples/store-passthrough` is the complete no-op example. A downstream crate can
+return any `ObjectStore` using `walgit_store_plugin::export_plugin!(factory)`.
+
+Configure `[store.plugin]` with an absolute `library` path and an `options` table.
+Every CLI storage operation uses the same constructor: HTTP serving, maintenance,
+follow, events, imports (including direct import), compaction, WAL, settings and
+repository administration. Initialization errors are fatal. With no plugin the
+existing binaries and object formats are unchanged. `cache.store_mount` is refused
+with a plugin because it bypasses the abstraction. Options are deployment config;
+credentials should be passed by environment/secret reference, not serialized in
+options or supplied by a repository/user.
+
+The factory receives the raw backend with the configured global prefix applied
+exactly once. The decorator sees **logical keys before that prefix**. A plugin
+needing bucket/domain identity must receive a stable identifier explicitly. It
+must not infer tenant authority from an unverified request.
+
+## V1 boundary
+
+`walgit_store_plugin_v1` returns the version/size-checked C descriptor in
+`walgit-store-plugin/src/abi.rs`. The ABI uses `repr(C)` structures, C function
+pointers, fixed-width status fields, pointer-sized byte lengths and opaque
+contexts. Both sides must target the same architecture/OS. No Rust trait object,
+allocator ownership, future, string layout or unwind crosses the boundary. Rust
+plugins use `crate-type = ["cdylib"]`; no Rust compiler-specific `dylib` ABI is used.
+
+Request and result metadata are bounded UTF-8 JSON described by `wire.rs`; bytes
+are separate, pull-based streams with at most 1 MiB per frame. JSON owns no pack
+bytes. PUT takes an explicit logical length; bytes/file/stream inputs all become
+streams at the boundary. LIST is streamed as newline-delimited metadata records.
+Reads return the whole object's logical size even when their body is a range.
+Errors preserve not-found, precondition, not-modified and retryable outcomes.
+Backing versions remain opaque strings. MIME types are advisory hints; the SDK
+forwards the known Git/JSON/protobuf/plain/octet-stream hints and drops unknown
+hints rather than leaking per-request static strings.
+
+Each allocation carries its allocating module's release callback. Each stream
+has exactly one owner; release drops/cancels it without draining. Calls on
+different stores/streams may run concurrently, while one stream is polled
+serially. An endpoint outlives its calls and result streams. Create consumes the
+inner endpoint on success and failure. Every exported callback catches unwinding
+panics and reports failure. A panic-abort build can still terminate the process.
+
+Callbacks are synchronous and run on blocking executor threads. The SDK bridges
+to the module's own Tokio runtime, preserving bounded streaming and backpressure;
+it never calls block_on from an async worker. Plugins are trusted native code,
+not a sandbox. Libraries stay mapped until process exit to keep runtime/channel
+teardown safe; upgrade by rolling the process, not hot-unloading a library.
+
+ABI evolution uses a new versioned symbol for incompatible layouts or semantics.
+Unknown operations fail, rather than falling back to the raw store. Test plugins
+against the pinned core revision before upgrades. Load only immutable library
+paths baked into the image or administrator-controlled read-only mounts.
+
+## Decorator obligations
+
+An adapter must preserve conditional publication/deletion, plaintext size/range
+semantics, listing order and isolation, cancellation and error categories.
+Transformers must not return raw signed URLs, acceleration targets or native
+compose unless those paths preserve the logical object. Those methods already
+default to unavailable/unsupported on `ObjectStore`. In particular, ciphertext
+concatenation is not plaintext composition. Existing data requires an explicit
+format/migration policy; plugin configuration is not a format migration.
+
+There are no extra bucket requests in the pass-through path (before → after:
+GET 1 → 1, PUT 1 → 1, manifest CAS 1 → 1). There is callback/thread-hop and
+serialization overhead; transformed stores must publish their own measured
+latency/throughput and request budgets.
+
+## Verification
+
+```sh
+just test-plugin
+```
+
+The recipe selects `.so` on Linux and `.dylib` on macOS. The integration test loads a real shared library and checks
+streaming/file uploads, ranges across frames, CAS races, conditional reads/deletes,
+listing, prefix application, interrupted uploads and stream lifetime after the
+store handle is dropped. Also run ordinary Git/maintenance tests through the
+plugin before deploying a custom adapter.

--- a/docs/STORAGE_PLUGINS.md
+++ b/docs/STORAGE_PLUGINS.md
@@ -3,7 +3,24 @@
 An optional, operator-installed `cdylib` decorates the configured S3, GCS or memory
 store. The stock build contains no encryption or application identity policy.
 `examples/store-passthrough` is the complete no-op example. A downstream crate can
-return any `ObjectStore` using `walgit_store_plugin::export_plugin!(factory)`.
+return any `ObjectStore` using `walgit_store_plugin::export_plugin!(factory)`. It must
+also declare `crate-type = ["cdylib"]` and depend on `abi_stable` itself, matching the
+version this crate pins.
+
+That dependency is a wart rather than a requirement of the design. The macro expands
+`#[abi_stable::export_root_module]` through a bare path, and an attribute macro resolves
+against the plugin crate's own root and extern prelude — not through this crate's
+`pub use abi_stable` re-export, which every other path in the expansion does use
+(`$crate::abi_stable::…`). Omitting it fails with `cannot find abi_stable in the crate
+root`, which points at the `export_plugin!` call site rather than at the missing
+manifest entry, so it costs a plugin author a confusing few minutes.
+
+Two fixes were tried and neither works: `#[$crate::abi_stable::export_root_module]`
+fails because `$crate` is not resolved in attribute position, and emitting
+`use $crate::abi_stable;` ahead of the attribute fails because attribute paths do not
+consult local `use` items. Removing the wart therefore means not applying
+`export_root_module` inside the macro at all — a larger change than it appears — so it
+is documented here instead.
 
 Configure `[store.plugin]` with an absolute `library` path and an `options` table.
 Every CLI storage operation uses the same constructor: HTTP serving, maintenance,
@@ -110,3 +127,24 @@ claim: no S3/GCS, Git, encryption or KMS is included. Safety and consistency dec
 the implementation choice; measure the real adapter's workload separately.
 The ignored `passthrough_overhead` test reproduces the current implementation's
 probe with `WALGIT_TEST_PLUGIN` set, `--ignored --nocapture --test-threads=1`.
+
+A second probe does isolate the boundary, by running the same encrypting workload with
+the codec in-process and again behind the plugin. Linux x86-64, release profile,
+`MemoryStore`, 16 MiB objects read in 1 MiB `BLOCK_SIZE`-aligned ranges (a pack's real
+read shape), best-of-4:
+
+| configuration | manual ABI prototype | abi_stable implementation |
+|---|---:|---:|
+| pass-through plugin — does no work at all | 1.21–1.58 GB/s | 1.70–1.99 GB/s |
+| AES-256-GCM in-process, no plugin | 1.66–1.76 GB/s | 1.67–1.76 GB/s |
+| AES-256-GCM through the plugin | 0.55–0.74 GB/s | 0.72–0.80 GB/s |
+
+Two things this shows that the latency table above cannot. The boundary is not free at
+throughput: under the manual ABI a plugin doing *nothing* was slower than doing
+AES-256-GCM in-process. And the checked implementation is 25–30% **faster**, because an
+owned `RVec` lets `Bytes` adopt the plugin's allocation instead of copying out of it —
+so on this workload safety and speed agree rather than trading off. The cost is per byte
+rather than per request: a whole-object read matches sixteen separate 1 MiB reads, and
+raising `MAX_FRAME` from 1 MiB to 8 MiB measured *worse*, so it is not tunable by framing.
+Still `MemoryStore` and no KMS: a decorator that calls out to a key service pays round
+trips this does not measure.

--- a/docs/STORAGE_PLUGINS.md
+++ b/docs/STORAGE_PLUGINS.md
@@ -111,6 +111,13 @@ plugin before deploying a custom adapter.
 
 ### Local overhead measurement
 
+Every figure in this section is the cost of a **loaded** plugin. With `[store.plugin]`
+unset, `open_store` returns the backend store itself: no decorator is constructed and
+none of this code sits on the request path, so the per-operation cost is zero rather
+than small. `DynStore` is `Arc<dyn ObjectStore>` either way, so the plugin seam adds no
+indirection to an undecorated store. What a plugin-free build still pays is compile
+time and binary size for `abi_stable`, never per-request latency.
+
 A macOS arm64, test-profile `MemoryStore` probe (three alternating runs; median
 of each run's mean full-GET latency) measured:
 

--- a/examples/store-passthrough/Cargo.toml
+++ b/examples/store-passthrough/Cargo.toml
@@ -8,7 +8,12 @@ publish = false
 [lib]
 crate-type = ["cdylib"]
 
+[[example]]
+name = "incompatible"
+crate-type = ["cdylib"]
+
 [dependencies]
+abi_stable = { version = "0.11.3", default-features = false }
 walgit-store-plugin.workspace = true
 walgit-store = { path = "../../crates/walgit-store", default-features = false }
 anyhow.workspace = true

--- a/examples/store-passthrough/Cargo.toml
+++ b/examples/store-passthrough/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "walgit-store-passthrough"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+walgit-store-plugin.workspace = true
+walgit-store = { path = "../../crates/walgit-store", default-features = false }
+anyhow.workspace = true
+serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/examples/store-passthrough/examples/incompatible.rs
+++ b/examples/store-passthrough/examples/incompatible.rs
@@ -1,0 +1,28 @@
+//! Deliberately incompatible module for the loader contract test, not a plugin.
+#![allow(unsafe_code, clippy::expl_impl_clone_on_copy)]
+use abi_stable::{StableAbi, prefix_type::PrefixTypeTrait};
+
+#[repr(C)]
+#[derive(StableAbi)]
+#[sabi(kind(Prefix(prefix_ref = WrongPluginRef)))]
+pub struct WrongPlugin {
+    #[sabi(last_prefix_field)]
+    pub create: extern "C" fn() -> u64,
+}
+impl abi_stable::library::RootModule for WrongPluginRef {
+    abi_stable::declare_root_module_statics! {WrongPluginRef}
+    const BASE_NAME: &'static str = "walgit_store_plugin";
+    const NAME: &'static str = "walgit_store_plugin";
+    const VERSION_STRINGS: abi_stable::sabi_types::VersionStrings =
+        abi_stable::package_version_strings!();
+}
+#[abi_stable::export_root_module]
+pub fn get_library() -> WrongPluginRef {
+    extern "C" fn incompatible_create() -> u64 {
+        0
+    }
+    WrongPlugin {
+        create: incompatible_create,
+    }
+    .leak_into_prefix()
+}

--- a/examples/store-passthrough/src/lib.rs
+++ b/examples/store-passthrough/src/lib.rs
@@ -1,0 +1,12 @@
+//! Minimal external-store example: no encryption, identity or cloud dependency.
+use walgit_store::DynStore;
+
+async fn passthrough(inner: DynStore, config: serde_json::Value) -> anyhow::Result<DynStore> {
+    anyhow::ensure!(
+        config.as_object().is_some_and(serde_json::Map::is_empty),
+        "passthrough takes no options"
+    );
+    Ok(inner)
+}
+
+walgit_store_plugin::export_plugin!(passthrough);

--- a/examples/store-passthrough/src/lib.rs
+++ b/examples/store-passthrough/src/lib.rs
@@ -1,7 +1,7 @@
 //! Minimal external-store example: no encryption, identity or cloud dependency.
 use walgit_store::DynStore;
 
-async fn passthrough(inner: DynStore, config: serde_json::Value) -> anyhow::Result<DynStore> {
+async fn create(inner: DynStore, config: serde_json::Value) -> anyhow::Result<DynStore> {
     anyhow::ensure!(
         config.as_object().is_some_and(serde_json::Map::is_empty),
         "passthrough takes no options"
@@ -9,4 +9,4 @@ async fn passthrough(inner: DynStore, config: serde_json::Value) -> anyhow::Resu
     Ok(inner)
 }
 
-walgit_store_plugin::export_plugin!(passthrough);
+walgit_store_plugin::export_plugin!(create);

--- a/justfile
+++ b/justfile
@@ -101,11 +101,12 @@ test:
 test-plugin:
     #!/usr/bin/env bash
     set -euo pipefail
-    {{t10}} cargo build -p walgit-store-passthrough
+    {{t10}} cargo build -p walgit-store-passthrough --lib --example incompatible
     target="${CARGO_TARGET_DIR:-target}"
     case "$(uname -s)" in Darwin) extension=dylib ;; *) extension=so ;; esac
     WALGIT_TEST_PLUGIN="$(cd "$target/debug" && pwd)/libwalgit_store_passthrough.$extension" \
-      {{t10}} cargo test -p walgit-store-plugin --test plugin -- --include-ignored
+    WALGIT_TEST_INCOMPATIBLE="$(cd "$target/debug" && pwd)/examples/libincompatible.$extension" \
+      {{t10}} cargo test -p walgit-store-plugin --test plugin -- --include-ignored --skip passthrough_overhead
 
 # Smart-HTTP end-to-end against real git (≈ 20 s) — run when touching smart.rs/receive/upload-pack/wal.
 e2e *ARGS:

--- a/justfile
+++ b/justfile
@@ -95,6 +95,17 @@ test:
     {{t5}} cargo test --workspace --lib --bins
     {{t10}} cargo test -p walgit-store -p walgit-git -p walgit-wal -p walgit-bundle --tests
     {{t10}} cargo test -p walgit-server --test web_api --test web_ui --test api_v1 --test static_http --test maintain --test routing_prefix --test lfs_upstream --test drain --test events --test follow --test policy
+    just test-plugin
+
+# Exercise the actual native boundary, including stream and store destruction.
+test-plugin:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    {{t10}} cargo build -p walgit-store-passthrough
+    target="${CARGO_TARGET_DIR:-target}"
+    case "$(uname -s)" in Darwin) extension=dylib ;; *) extension=so ;; esac
+    WALGIT_TEST_PLUGIN="$(cd "$target/debug" && pwd)/libwalgit_store_passthrough.$extension" \
+      {{t10}} cargo test -p walgit-store-plugin --test plugin -- --include-ignored
 
 # Smart-HTTP end-to-end against real git (≈ 20 s) — run when touching smart.rs/receive/upload-pack/wal.
 e2e *ARGS:

--- a/walgit.example.toml
+++ b/walgit.example.toml
@@ -65,6 +65,10 @@ anonymous_read = true             # must be false in oidc mode
 # trusted_forwarders = []                  # principals allowed to set X-Walgit-Principal (a front in front of a push broker)
 
 [store]
+# Optional trusted ObjectStore decorator, loaded by every storage-using command.
+# [store.plugin]
+# library = "/usr/local/lib/walgit/libwalgit_store_passthrough.so"
+# options = {} # plugin-owned options; never put plaintext credentials here
 backend = "s3"                    # "s3" (AWS, MinIO, rustfs, R2, Ceph, …) | "gcs" | "memory" (tests)
 bucket = "walgit"
 prefix = ""                       # global key prefix inside the bucket


### PR DESCRIPTION
Adds a plugin seam so capabilities can be added to walgit's storage layer without forking it or changing the `ObjectStore` trait. An operator-installed shared library decorates the configured S3, GCS or memory store.

**With no plugin configured there is no overhead — not low, zero.** Same stock binaries, same backend behaviour, same stored formats.

## What this unlocks

- **New capabilities without a fork.** A decorator is an ordinary `ObjectStore`, so anything expressible against that trait can be added downstream — encryption at rest, audit interception, compression, transparent double-writing during a bucket migration, extra caching — with no upstream change per capability.
- **Policy walgit should never carry.** Encryption keys, tenant identity and key management stay in the plugin. The decorator sees logical keys and bytes; nothing about who owns them enters this repo.
- **The stock binary ships as-is.** Operators install capabilities as a `.so` alongside it — no branch to rebase, no private build to keep current.
- **Per-deployment behaviour from one build.** Different deployments can layer different capabilities against the same released binary.

This PR adds the seam, not any particular capability. The only functional example in-tree is a no-op pass-through, and nothing here adds encryption, tenant identity, key-management policy, or Azure Blob support.

## How it works

```toml
[store.plugin]
library = "/opt/walgit/libmy_store.so"   # absolute path, operator-installed
options = { ... }                        # opaque JSON, handed to the factory
```

One CLI store constructor (`open_store`) applies the decorator across serving, maintenance and administrative commands. The factory receives the configured backend with its global prefix already applied once, so the decorator only ever sees logical keys. A downstream crate returns any `ObjectStore` via `walgit_store_plugin::export_plugin!(factory)`.

Built on **abi_stable 0.11.3** — checked root modules, `sabi_trait` endpoints, owned `RBox`/`RVec`/`RString`, following [Rotel's Rust processor SDK](https://github.com/streamfold/rotel/blob/v0.2.5/rotel_rust_processor_sdk/src/lib.rs) and its async bridge.

<details>
<summary><b>Boundary details and constraints</b></summary>

- Object bytes stream in frames of at most 1 MiB; operation metadata is bounded JSON.
- Versions and conditional operations cross unchanged; response streams retain their endpoints.
- Dropping a stream stops further polling without draining, but cannot interrupt a blocking call already in flight.
- Load/init failures stop startup. The SDK catches unwinding factory/request/poll panics as errors.
- Each library's root-module layout is checked **before** its storage factory is invoked. Mappings stay loaded until process exit.
- Plugins must target the same OS/arch and a compatible SDK/abi_stable version, and declare `crate-type = ["cdylib"]` plus a direct `abi_stable` dependency.

**Native plugins are trusted code.** ABI checks are not a sandbox — aborts or panicking destructors can still take down the process.

**Rejected combinations.** Bucket mounts are refused alongside plugins, because a mount bypasses the decorator entirely. A transforming plugin must also disable or correctly implement signed URLs, acceleration and native composition; the SDK cannot infer a plugin's transformation policy. Known MIME hints are preserved, unknown advisory ones omitted.

</details>

## Cost

**Unconfigured: zero, structurally.** `open_store` returns the backend store itself when `[store.plugin]` is unset — no decorator is constructed, so none of the code below is on the request path. `DynStore` is `Arc<dyn ObjectStore>` with or without this change, so an undecorated store gains no indirection either, and there is no per-operation branch to skip. Nothing in the tables below is paid by a deployment that doesn't load a plugin; the only residual cost of the seam existing is compile time and binary size for `abi_stable`.

**Loaded: measured below.** The hand-written ABI prototype (raw pointer handles, vtables, release callbacks) was replaced by the checked one. It also got faster, so the two probes are recorded for the record rather than as an argument.

**Interface latency** — macOS arm64, test-profile `MemoryStore` full GETs, three alternating runs, median of per-run means:

| Object bytes | Manual ABI prototype | abi_stable |
|---|---:|---:|
| 1 KiB | 66.12 µs | 66.92 µs |
| 1 MiB | 127.93 µs | 97.84 µs |
| 8 MiB | 840.27 µs | 602.14 µs |

This does **not** isolate the ABI library's cost — the new implementation also removes a receiver-side frame copy.

**Encryption overhead** — this one does isolate the boundary, running the same AES-256-GCM workload in-process and again behind the plugin. Linux x86-64, release profile, `MemoryStore`, 16 MiB objects read in 1 MiB `BLOCK_SIZE`-aligned ranges (a pack's real read shape), best-of-4:

| Configuration | Manual ABI prototype | abi_stable |
|---|---:|---:|
| Pass-through plugin — does no work at all | 1.21–1.58 GB/s | 1.70–1.99 GB/s |
| AES-256-GCM in-process, no plugin | 1.66–1.76 GB/s | 1.67–1.76 GB/s |
| AES-256-GCM through the plugin | 0.55–0.74 GB/s | 0.72–0.80 GB/s |

Two things the latency table cannot show:

1. **The boundary is not free at throughput.** Under the manual ABI, a plugin doing *nothing* was slower than doing AES-256-GCM in-process.
2. **The checked implementation is 25–30% faster**, because an owned `RVec` lets `Bytes` adopt the plugin's allocation instead of copying out of it.

The cost is **per byte, not per request** — a whole-object read matches sixteen separate 1 MiB reads, and raising `MAX_FRAME` from 1 MiB to 8 MiB measured *worse*. It is not tunable by framing.

⚠️ Still `MemoryStore` with no KMS. **A decorator that calls out to a key service pays round trips none of this measures.** No network, Git or KMS is in any figure above; these are not production throughput claims.

## Validation

> **The full validation is not all green.** Details below.

Checked at `2e1f168` on macOS arm64, Rust 1.97.1, Git 2.55.0:

| Check | Result |
|---|---|
| `just web-build` | ✅ Passed, incl. oxlint + TypeScript. Vite reports its pre-existing bundle-size advisory. |
| `just warnings` | ✅ Passed across all workspace targets. |
| `just test` | ✅ Passed, incl. all three native plugin contract/load-failure tests. |
| `cargo test -p walgit-server --test sim` | ✅ All 20 simulations passed. |
| S3 contract (`just test-s3`) | ✅ Passed against a local RustFS service, using local dev credentials and bucket rather than the recipe's hard-coded standalone defaults. |
| `just clippy` | ❌ Two `clippy::cast_lossless` errors at `walgit-wal/src/registry.rs:494–495` on macOS. **This file is identical to the PR base.** |
| `just e2e` | ⚠️ 42 passed, 1 failed, 1 ignored. `fetch_from_front_that_serves_the_base_remotely` failed after a commit-graph lock conflict left `has_commit_graph=false`; passed when run alone. |
| `just ci` | ❌ Failed at Clippy; constituent recipes then run separately, as above. |

The e2e failure is pre-existing and already documented in the base. Its test and harness are unchanged and use the in-memory store with no plugin. The isolated pass is diagnostic, not a substitute for a green full run. **No assertions were relaxed and no failing checks suppressed.**

Live GCS contracts and the ignored benchmark/soak tiers were not run — the GCS cases in the S3 test binary skipped because no GCS bucket was supplied.

**Since the latest commits** (docs + lint fix): `cargo clippy --workspace --all-targets -- -D warnings` now exits 0 on Linux x86-64. The base failed it on a missing-backticks doc lint in `walgit-cli`. The macOS `cast_lossless` errors above are base-identical and were not re-checked on macOS.

## Test coverage

The native-library contract covers streaming and file uploads, ranges, conditional reads/writes/deletes, CAS races, listing, single prefix application, interrupted uploads, and response lifetime after the store is dropped. A deliberately incompatible module verifies layout rejection *before* the storage factory is invoked; missing libraries and failed factories also fail. `just test` builds and runs these native fixtures; the timing probes stay opt-in (`passthrough_overhead`, `--ignored --nocapture --test-threads=1` with `WALGIT_TEST_PLUGIN` set).

## Docs

- `docs/STORAGE_PLUGINS.md` — the interface and the adapter's obligations.
- `docs/ROUNDTRIPS.md` — the round-trip budget row for a decorated store.